### PR TITLE
Support cats Ior and scalaz \&/

### DIFF
--- a/src/main/scala/com/mpc/scalats/core/Compiler.scala
+++ b/src/main/scala/com/mpc/scalats/core/Compiler.scala
@@ -194,6 +194,8 @@ object Compiler {
         compileTypeRef(i, inInterfaceContext)
       })
 
+    case ScalaModel.TupleRef(tpes) =>
+      TypeScriptModel.TupleType(tpes.map(compileTypeRef(_, inInterfaceContext)))
 
     case ScalaModel.UnknownTypeRef(u) =>
       TypeScriptModel.UnknownTypeRef(u)

--- a/src/main/scala/com/mpc/scalats/core/Emitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/Emitter.scala
@@ -40,9 +40,9 @@ trait Emitter {
     case DateRef | DateTimeRef => "Date"
     case ArrayRef(innerType) => s"${getTypeRefString(innerType)}[]"
     case NonEmptyArrayRef(innerType) => s"NonEmptyArray<${getTypeRefString(innerType)}>"
-    case CustomTypeRef(name, params) if params.isEmpty => name
-    case CustomTypeRef(name, params) if params.nonEmpty =>
-      s"$name<${params.map(getTypeRefString).mkString(", ")}>"
+    case CustomTypeRef(name, params) =>
+      if (params.isEmpty) name
+      else s"$name<${params.map(getTypeRefString).mkString(", ")}>"
     case UnknownTypeRef(typeName) => typeName
     case SimpleTypeRef(param) => param
 

--- a/src/main/scala/com/mpc/scalats/core/Emitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/Emitter.scala
@@ -51,6 +51,8 @@ trait Emitter {
 
     case MapType(keyType, valueType) => s"{ [key: ${getTypeRefString(keyType)}]: ${getTypeRefString(valueType)} }"
 
+    case TupleType(types) => types.map(getTypeRefString).mkString("[", ", ", "]")
+
     case NullRef => "null"
     case UndefinedRef => "undefined"
   }

--- a/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
@@ -139,9 +139,9 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case DateTimeRef => "DateFromISOString"
     case ArrayRef(innerType) => s"t.array(${getIoTsTypeString(innerType)})"
     case NonEmptyArrayRef(innerType) => s"nonEmptyArray(${getIoTsTypeString(innerType)})"
-    case CustomTypeRef(name, params) if params.isEmpty => customIoTsTypes(name)
-    case CustomTypeRef(name, params) if params.nonEmpty =>
-      s"${customIoTsTypes(name)}${params.map(getIoTsTypeString).mkString("(", ", ", ")")}"
+    case CustomTypeRef(name, params) =>
+      if (params.isEmpty) customIoTsTypes(name)
+      else s"${customIoTsTypes(name)}${params.map(getIoTsTypeString).mkString("(", ", ", ")")}"
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
@@ -163,9 +163,9 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case DateTimeRef => s"t.literal(new Date(`${value.toString.trim}`))"
     case ArrayRef(_) => s"t.literal([${value}])"
     case NonEmptyArrayRef(_) => s"t.literal(nonEmptyArray.of([${value}]))"
-    case CustomTypeRef(name, params) if params.isEmpty => codecName(name)
-    case CustomTypeRef(name, params) if params.nonEmpty =>
-      s"${codecName(name)}${params.map(getIoTsTypeWrappedVal(value, _)).mkString("(", ", ", ")")}"
+    case CustomTypeRef(name, params) =>
+      if (params.isEmpty) codecName(name)
+      else  s"${codecName(name)}${params.map(getIoTsTypeWrappedVal(value, _)).mkString("(", ", ", ")")}"
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => s"t.strict(${typeAsValArg(param)})"
     case UnionType(possibilities) => s"t.strict(t.union(${possibilities.map(getIoTsTypeWrappedVal(value, _)).mkString("[", ", ", "]")}))"
@@ -188,9 +188,12 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case DateTimeRef => s"`${value.toString.trim}`"
     case ArrayRef(_) => s"[${value}]"
     case NonEmptyArrayRef(_) => s"nonEmptyArray.of([${value}])"
-    case CustomTypeRef(name, params) if params.isEmpty => if (interfaceContext) interfaceName(name) else objectName(name)
-    case CustomTypeRef(name, params) if params.nonEmpty =>
-      s"${if (interfaceContext) interfaceName(name) else objectName(name)}${params.map(getIoTsTypeString).mkString("(", ", ", ")")}"
+    case CustomTypeRef(name, params) =>
+      if (params.isEmpty) {
+        if (interfaceContext) interfaceName(name) else objectName(name)
+      } else {
+        s"${if (interfaceContext) interfaceName(name) else objectName(name)}${params.map(getIoTsTypeString).mkString("(", ", ", ")")}"
+      }
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => if (interfaceContext) param else typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"

--- a/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
@@ -146,6 +146,7 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case SimpleTypeRef(param) => typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case MapType(keyType, valueType) => s"t.record(${getIoTsRecordKeyTypeString(keyType)}, ${getIoTsTypeString(valueType)})"
+    case TupleType(types) => s"t.tuple(${types.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case NullRef => "t.null"
     case UndefinedRef => "t.undefined"
   }
@@ -170,6 +171,7 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case SimpleTypeRef(param) => s"t.strict(${typeAsValArg(param)})"
     case UnionType(possibilities) => s"t.strict(t.union(${possibilities.map(getIoTsTypeWrappedVal(value, _)).mkString("[", ", ", "]")}))"
     case MapType(keyType, valueType) => s"t.strict(t.record(${getIoTsTypeWrappedVal(value, keyType)}, ${getIoTsTypeWrappedVal(value, valueType)}))"
+    case TupleType(types) => s"t.strict(t.tuple(${types.map(getIoTsTypeWrappedVal(value, _)).mkString("[", ", ", "]")}))"
     case NullRef => "t.literal(null)"
     case UndefinedRef => "t.literal(undefined)"
   }
@@ -198,6 +200,7 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case SimpleTypeRef(param) => if (interfaceContext) param else typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case MapType(keyType, valueType) => s"t.record(${getIoTsTypeString(keyType)}, ${getIoTsTypeString(valueType)})"
+    case TupleType(types) => s"t.tuple(${types.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case NullRef => "null"
     case UndefinedRef => "undefined"
   }

--- a/src/main/scala/com/mpc/scalats/core/ScalaModel.scala
+++ b/src/main/scala/com/mpc/scalats/core/ScalaModel.scala
@@ -39,6 +39,8 @@ object ScalaModel {
 
   case class SeqRef(innerType: TypeRef) extends TypeRef
 
+  case class TupleRef(typeArgs: ListSet[TypeRef]) extends TypeRef
+
   case class NonEmptySeqRef(innerType: TypeRef) extends TypeRef
 
   case class TypeMember(name: String, typeRef: TypeRef, value: Option[Any] = None)

--- a/src/main/scala/com/mpc/scalats/core/TypeScriptModel.scala
+++ b/src/main/scala/com/mpc/scalats/core/TypeScriptModel.scala
@@ -88,4 +88,6 @@ object TypeScriptModel {
   case class UnionType(possibilities: ListSet[TypeRef]) extends TypeRef
 
   case class MapType(keyType: TypeRef, valueType: TypeRef) extends TypeRef
+
+  case class TupleType(types: ListSet[TypeRef]) extends TypeRef
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.12-BL"
+version in ThisBuild := "0.5.13-BL"


### PR DESCRIPTION
Also refactors existing `match` statements to not use conditional guards, which cause the compiler to not emit exhaustivity warnings.