### PR TITLE
These encoder

### DIFF
--- a/src/main/scala/com/mpc/scalats/core/Compiler.scala
+++ b/src/main/scala/com/mpc/scalats/core/Compiler.scala
@@ -197,6 +197,11 @@ object Compiler {
     case ScalaModel.TupleRef(tpes) =>
       TypeScriptModel.TupleType(tpes.map(compileTypeRef(_, inInterfaceContext)))
 
+    case ScalaModel.TheseRef(lT, rT) =>
+      TypeScriptModel.TheseType(
+        compileTypeRef(lT, inInterfaceContext),
+        compileTypeRef(rT, inInterfaceContext))
+
     case ScalaModel.UnknownTypeRef(u) =>
       TypeScriptModel.UnknownTypeRef(u)
   }

--- a/src/main/scala/com/mpc/scalats/core/Emitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/Emitter.scala
@@ -49,7 +49,7 @@ trait Emitter {
     case UnionType(possibilities) =>
       possibilities.map(getTypeRefString).mkString("(", " | ", ")")
 
-    case TheseType(lT, rT) => "getTypeRefString"
+    case TheseType(lT, rT) => s"Th.These<${getTypeRefString(lT)}, ${getTypeRefString(rT)}>"
 
     case MapType(keyType, valueType) => s"{ [key: ${getTypeRefString(keyType)}]: ${getTypeRefString(valueType)} }"
 

--- a/src/main/scala/com/mpc/scalats/core/Emitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/Emitter.scala
@@ -49,6 +49,8 @@ trait Emitter {
     case UnionType(possibilities) =>
       possibilities.map(getTypeRefString).mkString("(", " | ", ")")
 
+    case TheseType(lT, rT) => "getTypeRefString"
+
     case MapType(keyType, valueType) => s"{ [key: ${getTypeRefString(keyType)}]: ${getTypeRefString(valueType)} }"
 
     case TupleType(types) => types.map(getTypeRefString).mkString("[", ", ", "]")

--- a/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
@@ -145,7 +145,9 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
-    case TheseType(lT, rT) => "getIoTsTypeString"
+    case TheseType(lT, rT) =>
+      getIoTsTypeString(UnionType(ListSet(lT, rT, TupleType(ListSet(lT, rT))))) +
+      s"""\n${indent(2)}.pipe(toThese("These", ${getIoTsTypeString(lT)}, ${getIoTsTypeString(rT)}))"""
     case MapType(keyType, valueType) => s"t.record(${getIoTsRecordKeyTypeString(keyType)}, ${getIoTsTypeString(valueType)})"
     case TupleType(types) => s"t.tuple(${types.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case NullRef => "t.null"

--- a/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
@@ -147,7 +147,7 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case TheseType(lT, rT) =>
       getIoTsTypeString(UnionType(ListSet(lT, rT, TupleType(ListSet(lT, rT))))) +
-      s"""\n${indent(2)}.pipe(toThese("These", ${getIoTsTypeString(lT)}, ${getIoTsTypeString(rT)}))"""
+      s"""\n${indent(2)}.pipe(theseC("These", ${getIoTsTypeString(lT)}, ${getIoTsTypeString(rT)}))"""
     case MapType(keyType, valueType) => s"t.record(${getIoTsRecordKeyTypeString(keyType)}, ${getIoTsTypeString(valueType)})"
     case TupleType(types) => s"t.tuple(${types.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case NullRef => "t.null"

--- a/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
@@ -145,6 +145,7 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
+    case TheseType(lT, rT) => "getIoTsTypeString"
     case MapType(keyType, valueType) => s"t.record(${getIoTsRecordKeyTypeString(keyType)}, ${getIoTsTypeString(valueType)})"
     case TupleType(types) => s"t.tuple(${types.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case NullRef => "t.null"
@@ -170,6 +171,7 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => s"t.strict(${typeAsValArg(param)})"
     case UnionType(possibilities) => s"t.strict(t.union(${possibilities.map(getIoTsTypeWrappedVal(value, _)).mkString("[", ", ", "]")}))"
+    case TheseType(lT, rT) => "getIoTsTypeWrappedVal"
     case MapType(keyType, valueType) => s"t.strict(t.record(${getIoTsTypeWrappedVal(value, keyType)}, ${getIoTsTypeWrappedVal(value, valueType)}))"
     case TupleType(types) => s"t.strict(t.tuple(${types.map(getIoTsTypeWrappedVal(value, _)).mkString("[", ", ", "]")}))"
     case NullRef => "t.literal(null)"
@@ -199,6 +201,7 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => if (interfaceContext) param else typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
+    case TheseType(lT, rT) => "getTypeWrappedVal"
     case MapType(keyType, valueType) => s"t.record(${getIoTsTypeString(keyType)}, ${getIoTsTypeString(valueType)})"
     case TupleType(types) => s"t.tuple(${types.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case NullRef => "null"

--- a/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/IoTsEmitter.scala
@@ -173,7 +173,11 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => s"t.strict(${typeAsValArg(param)})"
     case UnionType(possibilities) => s"t.strict(t.union(${possibilities.map(getIoTsTypeWrappedVal(value, _)).mkString("[", ", ", "]")}))"
-    case TheseType(lT, rT) => "getIoTsTypeWrappedVal"
+    case TheseType(lT, rT) =>
+      s"""t.strict(t.union([
+        ${getIoTsTypeWrappedVal(value, lT)},
+        ${getIoTsTypeWrappedVal(value, rT)},
+        ${getIoTsTypeWrappedVal(value, TupleType(ListSet(lT, rT)))}]))"""
     case MapType(keyType, valueType) => s"t.strict(t.record(${getIoTsTypeWrappedVal(value, keyType)}, ${getIoTsTypeWrappedVal(value, valueType)}))"
     case TupleType(types) => s"t.strict(t.tuple(${types.map(getIoTsTypeWrappedVal(value, _)).mkString("[", ", ", "]")}))"
     case NullRef => "t.literal(null)"
@@ -203,7 +207,9 @@ final class IoTsEmitter(val config: Config) extends Emitter {
     case UnknownTypeRef(unknown) => unknown
     case SimpleTypeRef(param) => if (interfaceContext) param else typeAsValArg(param)
     case UnionType(possibilities) => s"t.union(${possibilities.map(getIoTsTypeString).mkString("[", ", ", "]")})"
-    case TheseType(lT, rT) => "getTypeWrappedVal"
+    case TheseType(lT, rT) =>
+      s"""t.union([
+          ${getIoTsTypeString(lT)}, ${getIoTsTypeString(rT)}, ${getIoTsTypeString(TupleType(ListSet(lT, rT)))}])"""
     case MapType(keyType, valueType) => s"t.record(${getIoTsTypeString(keyType)}, ${getIoTsTypeString(valueType)})"
     case TupleType(types) => s"t.tuple(${types.map(getIoTsTypeString).mkString("[", ", ", "]")})"
     case NullRef => "null"

--- a/src/main/scala/com/mpc/scalats/core/ScalaModel.scala
+++ b/src/main/scala/com/mpc/scalats/core/ScalaModel.scala
@@ -41,6 +41,8 @@ object ScalaModel {
 
   case class TupleRef(typeArgs: ListSet[TypeRef]) extends TypeRef
 
+  case class TheseRef(leftType: TypeRef, rightType: TypeRef) extends TypeRef
+
   case class NonEmptySeqRef(innerType: TypeRef) extends TypeRef
 
   case class TypeMember(name: String, typeRef: TypeRef, value: Option[Any] = None)

--- a/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
+++ b/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
@@ -195,7 +195,7 @@ final class ScalaParser(logger: Logger, mirror: Mirror, excludeTypes: List[Type]
         BooleanRef
       case "String" =>
         StringRef
-      case "List" | "Seq" | "Set" => // TODO: Iterable
+      case "List" | "Seq" | "Set" | "Vector" => // TODO: Iterable
         val innerType = scalaType.typeArgs.head
         SeqRef(getTypeRef(innerType, typeParams))
       case "NonEmptyList" =>

--- a/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
+++ b/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
@@ -233,13 +233,7 @@ final class ScalaParser(logger: Logger, mirror: Mirror, excludeTypes: List[Type]
       }
 
       case "Ior" | """\&/""" =>
-        val typeRefL = getTypeRef(scalaType.typeArgs.head, typeParams)
-        val typeRefR = getTypeRef(scalaType.typeArgs.last, typeParams)
-
-        UnionRef(ListSet(
-          typeRefL,
-          typeRefR,
-          TupleRef(ListSet(typeRefL, typeRefR))))
+        TheseRef(getTypeRef(scalaType.typeArgs.head, typeParams), getTypeRef(scalaType.typeArgs.last, typeParams))
 
       case "Map" =>
         val keyType = scalaType.typeArgs.head

--- a/src/main/scala/com/mpc/scalats/core/TypeScriptModel.scala
+++ b/src/main/scala/com/mpc/scalats/core/TypeScriptModel.scala
@@ -87,6 +87,8 @@ object TypeScriptModel {
 
   case class UnionType(possibilities: ListSet[TypeRef]) extends TypeRef
 
+  case class TheseType(lT: TypeRef, rT: TypeRef) extends TypeRef
+
   case class MapType(keyType: TypeRef, valueType: TypeRef) extends TypeRef
 
   case class TupleType(types: ListSet[TypeRef]) extends TypeRef

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.14-BL"
+version in ThisBuild := "0.5.15-BL"


### PR DESCRIPTION
This pr handles converting `cats.data.Ior` into the equivalent `fp-ts These` type. This depends on providing a codec to convert `L | R | [L, R] => These<L, R>`, that's not included here.