### PR TITLE
Update SealedUnion Parsing

### DIFF
--- a/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
+++ b/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
@@ -113,7 +113,7 @@ final class ScalaParser(logger: Logger, mirror: Mirror, excludeType: Type => Boo
           tpe.typeSymbol.name.toString,
           tpe.toString,
           ListSet.empty ++ members,
-          parseTypes(possibilities),
+          possibilities.foldLeft(ListSet[TypeDef]())((b, a) => b ++ parseType(a)),
           tpe))
 
       case _ => Option.empty[SealedUnion]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.4-BL"
+version in ThisBuild := "0.6.5-BL"


### PR DESCRIPTION
Sealed unions only have direct subclasses as members now.