### PR TITLE
Entrypoint to get the code of an io-ts codec referring to a given type

### DIFF
--- a/src/main/scala/com/mpc/scalats/core/Compiler.scala
+++ b/src/main/scala/com/mpc/scalats/core/Compiler.scala
@@ -114,7 +114,7 @@ case class Compiler(config: Config) {
       compileTypeRef(scalaTaggedType.baseTypeRef, false),
       scalaTaggedType.tagTypeName)
 
-  private def compileTypeRef(
+  def compileTypeRef(
     scalaTypeRef: ScalaModel.TypeRef,
     inInterfaceContext: Boolean
   ): TypeScriptModel.TypeRef = scalaTypeRef match {
@@ -180,8 +180,8 @@ case class Compiler(config: Config) {
         compileTypeRef(lT, inInterfaceContext),
         compileTypeRef(rT, inInterfaceContext))
 
-    case ScalaModel.UnknownTypeRef(u, _) =>
-      TypeScriptModel.UnknownTypeRef(u)
+    case ScalaModel.UnknownTypeRef(u, t) =>
+      TypeScriptModel.UnknownTypeRef(u, t)
   }
 
   private implicit class BooleanOps(b: Boolean) {
@@ -200,7 +200,7 @@ case class Compiler(config: Config) {
         case TypeScriptModel.ArrayRef(r) => refersToRef(r, d, filterUnionName)
         case TypeScriptModel.SetRef(r) => refersToRef(r, d, filterUnionName)
         case TypeScriptModel.NonEmptyArrayRef(r) => refersToRef(r, d, filterUnionName)
-        case TypeScriptModel.UnknownTypeRef(n) => Eval.now(n == d.name)
+        case TypeScriptModel.UnknownTypeRef(n, _) => Eval.now(n == d.name)
         case TypeScriptModel.SimpleTypeRef(n) => Eval.now(n == d.name)
         case TypeScriptModel.UnionType(n, typeParams, _, _) =>
           (filterUnionName(n) == Some(d.name)).orM(typeParams.toList.existsM(refersToRef(_, d, filterUnionName)))

--- a/src/main/scala/com/mpc/scalats/core/Emitter.scala
+++ b/src/main/scala/com/mpc/scalats/core/Emitter.scala
@@ -51,7 +51,8 @@ trait Emitter extends TsImports.HelperSyntax {
     case CustomTypeRef(name, params, scalaType) =>
       val custom = imports.custom(scalaType, name).getOrElse(imports.lift(name))
       if (params.isEmpty) custom else custom |+| params.joinTypeParams(getTypeRefString)
-    case UnknownTypeRef(typeName) => typeName
+    case UnknownTypeRef(name, scalaType) =>
+      imports.custom(scalaType, name).getOrElse(imports.lift(name))
     case SimpleTypeRef(param) => param
 
     case UnionType(name, typeParams, possibilities, scalaType) =>

--- a/src/main/scala/com/mpc/scalats/core/TypeScriptModel.scala
+++ b/src/main/scala/com/mpc/scalats/core/TypeScriptModel.scala
@@ -59,7 +59,7 @@ object TypeScriptModel {
     val superInterface = None
   }
 
-  case class UnknownTypeRef(name: String) extends TypeRef
+  case class UnknownTypeRef(name: String, scalaType: Type) extends TypeRef
 
   case object JsonRef extends TypeRef
 


### PR DESCRIPTION
`TypeScriptGenerator.referenceCode` takes in a type, plus the full list of generated types, and produces the imports and code necessary to reference an `io-ts` codec for the type. For example:

```scala
val tpe = typeOf[Option[MyGeneratedType]]
val generated = Map("myGeneratedType.ts" -> List(tpe))
val (imports, code) = TypeScriptGenerator.referenceCode(..., generatedFiles = generated, tpe = tpe, ...)
/*
imports: List(
  import { optionFromNullable } from "io-ts-types/lib/optionFromNullable"
  import { myGeneratedTypeC } from "./myGeneratedType"
)
code: optionFromNullable(myGeneratedTypeC)
*/
```