### PR TITLE
Update sbt and sbt-tpolecat.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,18 +23,6 @@ lazy val root = project.in(file("."))
     crossScalaVersions := scalaVersions,
     scalaVersion := scalaVersions.find(_.startsWith("3.")).get,
 
-    scalacOptions ++= foldScalaV(scalaVersion.value)(
-      Seq(),
-      Seq(
-        "-Wvalue-discard",
-        "-Wunused:implicits",
-        "-Wunused:imports",
-        "-Wunused:locals",
-        "-Wunused:params",
-        "-Wunused:privates",
-        "-Wunused:unsafe-warn-patvars",
-      ),
-    ),
     Test / scalacOptions += "-Yretain-trees",
     Compile / doc / scalacOptions ++= foldScalaV(scalaVersion.value)(
       Seq(),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0
+sbt.version=1.9.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.2")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.4")
 
 resolvers += "bondlink-maven-repo" at "https://raw.githubusercontent.com/mblink/maven-repo/main"
 addSbtPlugin("bondlink" % "sbt-git-publish" % "0.0.5")

--- a/src/main/scala-3/scalats/TsGenerator.scala
+++ b/src/main/scala-3/scalats/TsGenerator.scala
@@ -232,15 +232,12 @@ final class TsGenerator(customType: TsCustomType, imports: TsImports.Available) 
     TsModel.ObjectField("_tag", TsModel.Literal(TsModel.String(TypeName("String")), tag), tag)
 
   /** Produces code for a type with a given set of fields */
-  private def generateFieldsCodec(state: State, fields: List[TsModel.InterfaceField | TsModel.ObjectField]): Generated =
+  private def generateFieldsCodec(state: State, fields: List[TsModel.Field]): Generated =
     imports.iotsTypeFunction(
       "{\n" |+|
-      fields.map {
-        case TsModel.InterfaceField(name, tpe) => (name, tpe)
-        case TsModel.ObjectField(name, tpe, _) => (name, tpe)
-      }.intercalateMap(imports.lift(",\n")) { case (name, tpe) =>
-        "  " |+| name |+| ": " |+| generate(state.copy(top = false), tpe).foldMap(_._2)
-      } |+|
+      fields.intercalateMap(imports.lift(",\n"))(field =>
+        "  " |+| field.name |+| ": " |+| generate(state.copy(top = false), field.tpe).foldMap(_._2)
+      ) |+|
       "\n}"
     )
 

--- a/src/main/scala-3/scalats/TsGenerator.scala
+++ b/src/main/scala-3/scalats/TsGenerator.scala
@@ -251,7 +251,9 @@ final class TsGenerator(customType: TsCustomType, imports: TsImports.Available) 
     val taggedValueType = cap(taggedCodecName).stripSuffix("C")
     val fields = parent.fold(Nil)(_ => List(tagField(name))) ++ fields0
 
-    lazy val fullCodec: Generated = state.wrapCodec(generateFieldsCodec(state, fields))
+    lazy val fullCodec: Generated = state.wrapCodec(
+      generateFieldsCodec(state, fields.map(f => TsModel.ObjectField(f.name, TsModel.Literal(f.tpe, f.value), f.value)))
+    )
 
     lazy val minimalTaggedCodec: Generated =
       // Codec with only `_tag` value

--- a/src/main/scala-3/scalats/TsModel.scala
+++ b/src/main/scala-3/scalats/TsModel.scala
@@ -25,6 +25,10 @@ object TsModel {
     val typeName = TypeName(name)
     val typeArgs = Nil
   }
+  case class Literal(tpe: TsModel, value: Any) extends TsModel {
+    val typeName = tpe.typeName
+    val typeArgs = Nil
+  }
   case class Json(typeName: TypeName) extends TsModel {
     val typeArgs = Nil
   }

--- a/src/main/scala-3/scalats/TsModel.scala
+++ b/src/main/scala-3/scalats/TsModel.scala
@@ -18,8 +18,12 @@ sealed trait TsModel {
 }
 
 object TsModel {
-  case class ObjectField(name: scala.Predef.String, tpe: TsModel, value: Any)
-  case class InterfaceField(name: scala.Predef.String, tpe: TsModel)
+  sealed trait Field {
+    val name: scala.Predef.String
+    val tpe: TsModel
+  }
+  case class ObjectField(name: scala.Predef.String, tpe: TsModel, value: Any) extends Field
+  case class InterfaceField(name: scala.Predef.String, tpe: TsModel) extends Field
 
   case class TypeParam(name: scala.Predef.String) extends TsModel {
     val typeName = TypeName(name)

--- a/src/main/scala-3/scalats/TsParser.scala
+++ b/src/main/scala-3/scalats/TsParser.scala
@@ -172,6 +172,7 @@ final class TsParser()(using override val ctx: Quotes) extends ReflectionUtils {
         !(
           s.privateWithin.nonEmpty ||
           s.protectedWithin.nonEmpty ||
+          s.flags.is(Flags.Given) ||
           s.flags.is(Flags.Private) ||
           s.flags.is(Flags.PrivateLocal) ||
           s.flags.is(Flags.Protected)

--- a/src/main/scala-3/scalats/package.scala
+++ b/src/main/scala-3/scalats/package.scala
@@ -104,5 +104,5 @@ def referenceCode(model: TsModel)(
   imports: TsImports.Available,
 ): Generated = {
   val generator = new TsGenerator(customType, imports)
-  generator.generate(generator.State(false, identity), model).foldMap(_._2)
+  generator.generate(generator.State(false, generator.WrapCodec.id), model).foldMap(_._2)
 }

--- a/src/test/scala-3/scalats/tests/ObjectTest.scala
+++ b/src/test/scala-3/scalats/tests/ObjectTest.scala
@@ -1,0 +1,47 @@
+package scalats
+package tests
+
+import io.circe.{Decoder, Encoder, Json, JsonObject}
+import scalats.tests.arbitrary.given
+
+object ObjectTest {
+  case object Foo {
+    val name = "foo"
+    given decoder: Decoder[Foo.type] =
+      Decoder.instance(_.get["foo"]("name").map(_ => Foo))
+
+    given encoder: Encoder[Foo.type] =
+      Encoder.AsObject.instance(foo => JsonObject.singleton("name", Json.fromString(foo.name)))
+  }
+
+  val expectedFooCode = """
+import * as t from "io-ts";
+
+export const foo = {
+  name: `foo`
+} as const;
+
+export const fooC = t.type({
+  name: t.string
+});
+export type FooC = typeof fooC;
+export type Foo = t.TypeOf<FooC>;
+""".trim
+
+  val fooFile = "foo.ts"
+
+  val types = Map(
+    fooFile -> (List(parse[Foo.type]), expectedFooCode),
+  )
+}
+
+class ObjectTest extends CodecTest[ObjectTest.Foo.type](
+  outputDir / "object",
+  ObjectTest.types,
+  "fooC",
+  "fooC",
+  ObjectTest.fooFile,
+) {
+  // `Foo.type` is a singleton so we can set min successful tests to 1 as nothing will change from test to test
+  override def scalaCheckTestParameters = super.scalaCheckTestParameters.withMinSuccessfulTests(1)
+}

--- a/src/test/scala-3/scalats/tests/ObjectTest.scala
+++ b/src/test/scala-3/scalats/tests/ObjectTest.scala
@@ -1,28 +1,36 @@
 package scalats
 package tests
 
-import io.circe.{Decoder, Encoder, Json, JsonObject}
+import io.circe.{Decoder, Encoder, JsonObject}
+import io.circe.syntax.*
 import scalats.tests.arbitrary.given
 
 object ObjectTest {
   case object Foo {
-    val name = "foo"
+    val int = 1
+    val str = "test"
+
     given decoder: Decoder[Foo.type] =
-      Decoder.instance(_.get["foo"]("name").map(_ => Foo))
+      Decoder.instance(c => for {
+        _ <- c.get[1]("int")
+        _ <- c.get["test"]("str")
+      } yield Foo)
 
     given encoder: Encoder[Foo.type] =
-      Encoder.AsObject.instance(foo => JsonObject.singleton("name", Json.fromString(foo.name)))
+      Encoder.AsObject.instance(foo => JsonObject("int" := foo.int, "str" := foo.str))
   }
 
   val expectedFooCode = """
 import * as t from "io-ts";
 
 export const foo = {
-  name: `foo`
+  int: 1,
+  str: `test`
 } as const;
 
 export const fooC = t.type({
-  name: t.literal(`foo`)
+  int: t.literal(1),
+  str: t.literal(`test`)
 });
 export type FooC = typeof fooC;
 export type Foo = t.TypeOf<FooC>;

--- a/src/test/scala-3/scalats/tests/ObjectTest.scala
+++ b/src/test/scala-3/scalats/tests/ObjectTest.scala
@@ -22,7 +22,7 @@ export const foo = {
 } as const;
 
 export const fooC = t.type({
-  name: t.string
+  name: t.literal(`foo`)
 });
 export type FooC = typeof fooC;
 export type Foo = t.TypeOf<FooC>;

--- a/src/test/scala-3/scalats/tests/UnionTest.scala
+++ b/src/test/scala-3/scalats/tests/UnionTest.scala
@@ -27,21 +27,25 @@ import { pipe } from "fp-ts/lib/function";
 import * as Ord from "fp-ts/lib/Ord";
 
 export const bar = {
+  _tag: `Bar`,
   int: 1,
-  str: `bar`,
-  _tag: `Bar`
+  str: `bar`
 } as const;
 
-export const barTaggedC = t.type({ _tag: t.literal(`Bar`) });
+export const barTaggedC = t.type({
+  _tag: t.literal(`Bar`)
+});
 export type BarTaggedC = typeof barTaggedC;
 export type BarTagged = t.TypeOf<BarTaggedC>;
 export type Bar = BarTagged & typeof bar;
 export const barC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   `Bar`,
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
-  (u: unknown): E.Either<t.Errors, Bar> =>pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
+  (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
 ));
+export type BarC = typeof barC;
+
 
 export const bazC = t.type({
   _tag: t.literal(`Baz`),

--- a/src/test/scala-3/scalats/tests/UnionWithTypeParamTest.scala
+++ b/src/test/scala-3/scalats/tests/UnionWithTypeParamTest.scala
@@ -25,21 +25,25 @@ import * as E from "fp-ts/lib/Either";
 import * as t from "io-ts";
 
 export const bar = {
+  _tag: `Bar`,
   data: `bar`,
-  int: 1,
-  _tag: `Bar`
+  int: 1
 } as const;
 
-export const barTaggedC = t.type({ _tag: t.literal(`Bar`) });
+export const barTaggedC = t.type({
+  _tag: t.literal(`Bar`)
+});
 export type BarTaggedC = typeof barTaggedC;
 export type BarTagged = t.TypeOf<BarTaggedC>;
 export type Bar = BarTagged & typeof bar;
 export const barC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   `Bar`,
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
-  (u: unknown): E.Either<t.Errors, Bar> =>pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
+  (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
 ));
+export type BarC = typeof barC;
+
 
 export class bazCC<A1 extends t.Mixed>{ codec = (A1: A1) => t.type({
   _tag: t.literal(`Baz`),


### PR DESCRIPTION
`case object`s without a parent are exported as an object containing their `val` fields, e.g.

```scala
case object Foo {
  val int = 1
  val str = "test"
}
```

```ts
import * as t from "io-ts";

export const foo = {
  int: 1,
  str: `test`
} as const;

export const fooC = t.type({
  int: t.literal(1),
  str: t.literal(`test`)
});
export type FooC = typeof fooC;
export type Foo = t.TypeOf<FooC>;
```