### PR TITLE
Use ES6 `Map`s for non-string keys in Scala `Map`s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val root = project.in(file("."))
   .settings(
     name := "scala-ts",
     organization := "bondlink",
-    version := "0.11.2",
+    version := "0.12.0-RC1",
     crossScalaVersions := scalaVersions,
     scalaVersion := scalaVersions.find(_.startsWith("3.")).get,
 

--- a/src/main/scala-3/scalats/TsImports.scala
+++ b/src/main/scala-3/scalats/TsImports.scala
@@ -218,6 +218,7 @@ object TsImports {
     fptsPipe: (String, String) = ("pipe", "fp-ts/lib/function"),
     iots: String = "io-ts",
     iotsDateTime: (String, String) = ("DateFromISOString", "io-ts-types/lib/DateFromISOString"),
+    iotsReadonlyMapFromEntries: (String, String) = ("readonlyMapFromEntries", "io-ts-types/lib/readonlyMapFromEntries"),
     iotsReadonlyNonEmptyArray: (String, String) = ("readonlyNonEmptyArray", "io-ts-types/lib/readonlyNonEmptyArray"),
     iotsReadonlySetFromArray: (String, String) = ("readonlySetFromArray", "io-ts-types/lib/readonlySetFromArray"),
     iotsNumberFromString: (String, String) = ("NumberFromString", "io-ts-types/lib/NumberFromString"),
@@ -351,6 +352,8 @@ object TsImports {
 
     /** Reference to the configured `iotsDateTime` value */
     final lazy val iotsDateTime = namedImport(tsi.iotsDateTime)
+    /** Helper to call the configured `iotsReadonlyMapFromEntries` function */
+    final lazy val iotsReadonlyMapFromEntries = CallableImport(namedImport(tsi.iotsReadonlyMapFromEntries))
     /** Helper to call the configured `iotsReadonlyNonEmptyArray` function */
     final lazy val iotsReadonlyNonEmptyArray = CallableImport(namedImport(tsi.iotsReadonlyNonEmptyArray))
     /** Helper to call the configured `iotsReadonlySetFromArray` function */

--- a/src/main/scala-3/scalats/TypeName.scala
+++ b/src/main/scala-3/scalats/TypeName.scala
@@ -19,7 +19,7 @@ package scalats
  * ```
  */
 class TypeName private (val raw: String) {
-  final val full: String = raw.split('[').head
+  final val full: String = raw.split('[').head.stripSuffix(".type")
   final val base: String = full.split('.').last
   override final lazy val toString: String = raw
 }


### PR DESCRIPTION
Migrates to use `readonlyMapFromEntries` from `io-ts-types` for Scala `Map`s that have non-string keys