### PR TITLE
Add `TsCustomOrd` type to support user-provided `Ord` instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val root = project.in(file("."))
   .settings(
     name := "scala-ts",
     organization := "bondlink",
-    version := "0.12.0",
+    version := "0.13.0-RC1",
     crossScalaVersions := scalaVersions,
     scalaVersion := scalaVersions.find(_.startsWith("3.")).get,
 

--- a/src/main/scala-3/scalats/TsCustomOrd.scala
+++ b/src/main/scala-3/scalats/TsCustomOrd.scala
@@ -1,0 +1,13 @@
+package scalats
+
+/**
+ * Used as an argument to [[scalats.TsGenerator]] to optionally provide custom `Ord` instances for certain types
+ */
+trait TsCustomOrd {
+  def apply(typeName: TypeName): Option[Generated]
+}
+
+object TsCustomOrd {
+  /** An instance that does not provide custom `Ord` instances for any types */
+  val none = new TsCustomOrd { def apply(typeName: TypeName) = None }
+}

--- a/src/main/scala-3/scalats/TsModel.scala
+++ b/src/main/scala-3/scalats/TsModel.scala
@@ -90,6 +90,6 @@ object TsModel {
     val typeArgs = Nil
   }
   case class Union(typeName: TypeName, typeArgs: List[TsModel], possibilities: List[Object | Interface]) extends TsModel
-  case class UnionRef(typeName: TypeName, typeArgs: List[TsModel]) extends TsModel
+  case class UnionRef(typeName: TypeName, typeArgs: List[TsModel], possibilities: List[ObjectRef | InterfaceRef]) extends TsModel
   case class Unknown(typeName: TypeName, typeArgs: List[TsModel]) extends TsModel
 }

--- a/src/main/scala-3/scalats/package.scala
+++ b/src/main/scala-3/scalats/package.scala
@@ -32,9 +32,10 @@ inline def parseReference[A]: TsModel = ${ parseReferenceImpl[A] }
  */
 def generateAll(all: Map[File, List[TsModel]], debug: Boolean = false, debugFilter: String = "")(
   using customType: TsCustomType,
+  customOrd: TsCustomOrd,
   imports: TsImports.Available,
 ): List[(File, (List[(Option[TypeName], Generated)], ReferencedTypes))] = {
-  val generator = new TsGenerator(customType, imports, debug, debugFilter)
+  val generator = new TsGenerator(customType, customOrd, imports, debug, debugFilter)
   all.toList.foldMap { case (file, models) =>
     Map(file.toString -> (models.flatMap(generator.generateTopLevel), models.foldMap(generator.referencedTypes)))
   }.toList.map { case (file, (types, refs)) => (new File(file), (types.distinctBy(_._1.map(_.full)), refs)) }
@@ -72,7 +73,11 @@ def writeAll(all: List[(File, (List[(Option[TypeName], Generated)], ReferencedTy
  *
  * @param all A mapping of files to parsed types
  */
-def writeAll(all: Map[File, List[TsModel]], debug: Boolean = false, debugFilter: String = "")(using customType: TsCustomType, imports: TsImports.Available): Unit =
+def writeAll(all: Map[File, List[TsModel]], debug: Boolean = false, debugFilter: String = "")(
+  using customType: TsCustomType,
+  customOrd: TsCustomOrd,
+  imports: TsImports.Available,
+): Unit =
   writeAll(generateAll(all, debug, debugFilter))
 
 /**
@@ -101,8 +106,9 @@ def resolve(
  */
 def referenceCode(model: TsModel)(
   using customType: TsCustomType,
+  customOrd: TsCustomOrd,
   imports: TsImports.Available,
 ): Generated = {
-  val generator = new TsGenerator(customType, imports)
+  val generator = new TsGenerator(customType, customOrd, imports)
   generator.generate(generator.State(false, generator.WrapCodec.id), model).foldMap(_._2)
 }

--- a/src/test/scala-3/scalats/tests/UnionWithInterfaceTest.scala
+++ b/src/test/scala-3/scalats/tests/UnionWithInterfaceTest.scala
@@ -4,7 +4,7 @@ package tests
 import io.circe.{Decoder, Encoder}
 import scalats.tests.arbitrary.given
 
-object UnionTest {
+object UnionWithInterfaceTest {
   sealed trait Foo {
     val int: Int
     val str: String
@@ -20,11 +20,9 @@ object UnionTest {
   case class Baz(int: Int, str: String) extends Foo
 
   val expectedFooCode = """
-import * as t from "io-ts";
-import { Ord as stringOrd } from "fp-ts/lib/string";
-import * as E from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
-import * as Ord from "fp-ts/lib/Ord";
+import * as E from "fp-ts/lib/Either";
+import * as t from "io-ts";
 
 export const bar = {
   _tag: `Bar`,
@@ -64,7 +62,6 @@ export const FooCU = t.union([barC, bazC]);
 export type FooCU = typeof FooCU;
 export type FooU = t.TypeOf<FooCU>;
 
-export const fooOrd: Ord.Ord<FooU> = pipe(stringOrd, Ord.contramap(x => x._tag));
 export type FooMap<A> = { [K in FooName]: A };
 """.trim
 
@@ -75,10 +72,10 @@ export type FooMap<A> = { [K in FooName]: A };
   )
 }
 
-class UnionTest extends CodecTest[UnionTest.Foo](
-  outputDir / "union",
-  UnionTest.types,
+class UnionWithInterfaceTest extends CodecTest[UnionWithInterfaceTest.Foo](
+  outputDir / "unionWithInterface",
+  UnionWithInterfaceTest.types,
   "FooCU",
   "FooCU",
-  UnionTest.fooFile,
+  UnionWithInterfaceTest.fooFile,
 )

--- a/src/test/scala-3/scalats/tests/UnionWithObjectsTest.scala
+++ b/src/test/scala-3/scalats/tests/UnionWithObjectsTest.scala
@@ -1,0 +1,100 @@
+package scalats
+package tests
+
+import io.circe.{Decoder, Encoder}
+import scalats.tests.arbitrary.given
+
+object UnionWithObjectsTest {
+  sealed trait Foo {
+    val int: Int
+    val str: String
+  }
+  object Foo {
+    given decoder: Decoder[Foo] = Decoder.derivedConfigured
+    given encoder: Encoder[Foo] = Encoder.AsObject.derivedConfigured
+  }
+  case object Bar extends Foo {
+    val int = 1
+    val str = "bar"
+  }
+  case object Baz extends Foo {
+    val int = 2
+    val str = "baz"
+  }
+
+  val expectedFooCode = """
+import * as t from "io-ts";
+import { Ord as stringOrd } from "fp-ts/lib/string";
+import * as E from "fp-ts/lib/Either";
+import { pipe } from "fp-ts/lib/function";
+import * as Ord from "fp-ts/lib/Ord";
+
+export const bar = {
+  _tag: `Bar`,
+  int: 1,
+  str: `bar`
+} as const;
+
+export const barTaggedC = t.type({
+  _tag: t.literal(`Bar`)
+});
+export type BarTaggedC = typeof barTaggedC;
+export type BarTagged = t.TypeOf<BarTaggedC>;
+export type Bar = BarTagged & typeof bar;
+export const barC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
+  `Bar`,
+  (u: unknown): u is Bar => E.isRight(c.decode(u)),
+  (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
+  (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
+));
+export type BarC = typeof barC;
+
+
+export const baz = {
+  _tag: `Baz`,
+  int: 2,
+  str: `baz`
+} as const;
+
+export const bazTaggedC = t.type({
+  _tag: t.literal(`Baz`)
+});
+export type BazTaggedC = typeof bazTaggedC;
+export type BazTagged = t.TypeOf<BazTaggedC>;
+export type Baz = BazTagged & typeof baz;
+export const bazC = pipe(bazTaggedC, c => new t.Type<Baz, BazTagged>(
+  `Baz`,
+  (u: unknown): u is Baz => E.isRight(c.decode(u)),
+  (u: unknown): E.Either<t.Errors, Baz> => pipe(c.decode(u), E.map(x => ({ ...x, ...baz }))),
+  (x: Baz): BazTagged => ({ ...x, _tag: `Baz`}),
+));
+export type BazC = typeof bazC;
+
+
+export const allFooC = [barC, bazC] as const;
+export const allFooNames = [`Bar`, `Baz`] as const;
+export type FooName = (typeof allFooNames)[number];
+
+export const FooCU = t.union([barC, bazC]);
+export type FooCU = typeof FooCU;
+export type FooU = t.TypeOf<FooCU>;
+
+export const fooOrd: Ord.Ord<FooU> = pipe(stringOrd, Ord.contramap(x => x._tag));
+export const allFoo = [bar, baz] as const;
+export type FooMap<A> = { [K in FooName]: A };
+""".trim
+
+  val fooFile = "foo.ts"
+
+  val types = Map(
+    fooFile -> (List(parse[Foo]), expectedFooCode),
+  )
+}
+
+class UnionWithObjectsTest extends CodecTest[UnionWithObjectsTest.Foo](
+  outputDir / "unionWithObjects",
+  UnionWithObjectsTest.types,
+  "FooCU",
+  "FooCU",
+  UnionWithObjectsTest.fooFile,
+)

--- a/src/test/scala-3/scalats/tests/package.scala
+++ b/src/test/scala-3/scalats/tests/package.scala
@@ -15,6 +15,7 @@ extension(file: File) {
 val outputDir = BuildInfo.testsDir / "output"
 
 given customType: TsCustomType = TsCustomType.none
+given customOrd: TsCustomOrd = TsCustomOrd.none
 given imports: TsImports.Available = TsImports.Available(TsImports.Config())
 
 given circeConfig: CirceConfig = CirceConfig(discriminator = Some("_tag"))


### PR DESCRIPTION
Also updates union logic to not generate an `Ord` when the type in Scala is a mix of `case class`es and `case object`s -- we can't easily generate an `Ord` for the `case class` members, so we don't generate one for the union as a whole.