### PR TITLE
Explicit types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [3.3.3]
+        scala: [3.3.4]
         java: [temurin@8, temurin@11, temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
@@ -63,6 +63,9 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val root = project.in(file("."))
   .settings(
     name := "scala-ts",
     organization := "bondlink",
-    version := "0.15.3",
+    version := "0.16.0-RC1",
     scalaVersion := scalaV,
 
     Compile / doc / scalacOptions += "-skip-by-regex:^scalats\\.BuildInfo\\$$",

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val scalaV = "3.3.3"
+val scalaV = "3.3.4"
 
 ThisBuild / scalaVersion := scalaV
 ThisBuild / crossScalaVersions := Seq(scalaV)
@@ -20,13 +20,21 @@ ThisBuild / githubWorkflowBuild := Seq(
 
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 
-lazy val cats = "org.typelevel" %% "cats-core" % "2.10.0"
-def circe(proj: String) = "io.circe" %% s"circe-$proj" % "0.14.6"
-lazy val joda = "joda-time" % "joda-time" % "2.12.7"
-def munit(proj: String = "") = "org.scalameta" %% s"munit${if (proj == "") "" else s"-$proj"}" % "1.0.0-M11" % Test
-lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.17.0" % Test
+lazy val cats = "org.typelevel" %% "cats-core" % "2.12.0"
+def circe(proj: String) = "io.circe" %% s"circe-$proj" % "0.14.10"
+lazy val joda = "joda-time" % "joda-time" % "2.13.0"
+def munit(proj: String = "") =
+  "org.scalameta" %%
+    s"munit${if (proj == "") "" else s"-$proj"}" %
+    (proj match {
+      case "" => "1.0.2"
+      case "scalacheck" => "1.0.0"
+      case _ => sys.error(s"Unknown munit project: $proj")
+    }) %
+    Test
+lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.18.1" % Test
 lazy val scalaz = "org.scalaz" %% "scalaz-core" % "7.3.8"
-lazy val slf4j = "org.slf4j" % "slf4j-api" % "2.0.12"
+lazy val slf4j = "org.slf4j" % "slf4j-api" % "2.0.16"
 
 lazy val root = project.in(file("."))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val root = project.in(file("."))
   .settings(
     name := "scala-ts",
     organization := "bondlink",
-    version := "0.16.0-RC1",
+    version := "0.16.0-RC2",
     scalaVersion := scalaV,
 
     Compile / doc / scalacOptions += "-skip-by-regex:^scalats\\.BuildInfo\\$$",

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val root = project.in(file("."))
   .settings(
     name := "scala-ts",
     organization := "bondlink",
-    version := "0.16.0-RC2",
+    version := "0.16.0-RC3",
     scalaVersion := scalaV,
 
     Compile / doc / scalacOptions += "-skip-by-regex:^scalats\\.BuildInfo\\$$",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
-addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.23.0")
-addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")
+addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.24.0")
+addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.2")
 
 resolvers += "bondlink-maven-repo" at "https://raw.githubusercontent.com/mblink/maven-repo/main"
 addSbtPlugin("bondlink" % "sbt-git-publish" % "0.0.5")

--- a/src/main/scala/scalats/ReferenceCode.scala
+++ b/src/main/scala/scalats/ReferenceCode.scala
@@ -1,0 +1,7 @@
+package scalats
+
+case class ReferenceCode[ValueType[_]](
+  valueType: ValueType[Generated],
+  codecType: Generated,
+  codecValue: Generated,
+)

--- a/src/main/scala/scalats/TsCustomType.scala
+++ b/src/main/scala/scalats/TsCustomType.scala
@@ -5,10 +5,14 @@ package scalats
  * for certain types
  */
 trait TsCustomType {
-  def apply(name: String): Option[Generated]
+  def tpe(name: String): Option[Generated]
+  def value(name: String): Option[Generated]
 }
 
 object TsCustomType {
   /** An instance that does not customize generation behavior for any types */
-  val none = new TsCustomType { def apply(name: String) = None }
+  val none = new TsCustomType {
+    def tpe(name: String) = None
+    def value(name: String) = None
+  }
 }

--- a/src/main/scala/scalats/TsCustomType.scala
+++ b/src/main/scala/scalats/TsCustomType.scala
@@ -5,14 +5,16 @@ package scalats
  * for certain types
  */
 trait TsCustomType {
-  def tpe(name: String): Option[Generated]
+  def codecType(name: String): Option[Generated]
+  def valueType(name: String): Option[Generated]
   def value(name: String): Option[Generated]
 }
 
 object TsCustomType {
   /** An instance that does not customize generation behavior for any types */
   val none = new TsCustomType {
-    def tpe(name: String) = None
+    def codecType(name: String) = None
+    def valueType(name: String) = None
     def value(name: String) = None
   }
 }

--- a/src/main/scala/scalats/TsGenerator.scala
+++ b/src/main/scala/scalats/TsGenerator.scala
@@ -92,7 +92,7 @@ final class TsGenerator(
 
   case class WrapCodec(custom: Generated => (Generated => Generated => Generated => Generated) => Generated) {
     final def apply(codec: Generated): Generated =
-      custom(codec)(codecType => codec => valueType => codecType |+| codec |+| valueType)
+      custom(codec)(codecType => valueType => codec => codecType |+| valueType |+| codec)
   }
 
   object WrapCodec {
@@ -391,7 +391,7 @@ final class TsGenerator(
         ",\n" |+|
         "  (x: " |+| valueType |+| "): " |+| taggedValueType |+| " => ({ ...x, _tag: `" |+| name |+| "`}),\n" |+|
         ")"
-      ))(codecType => codec => _ /* we create our own value type */ =>
+      ))(codecType => _ /* we create our own value type */ => codec =>
          // Full value type
          "export type " |+| valueType |+| " = " |+| taggedValueType |+| " & typeof " |+| constName |+| ";\n" |+|
          codecType |+|
@@ -802,9 +802,9 @@ final class TsGenerator(
         f(
           "export type " |+| codecType |+| tpArgsIots |+| " = " |+| generateCodecType(model) |+| ";\n"
         )(
-          "export const " |+| codecName |+| " = " |+| tpArgsIots |+| fnArgs |+| codec |+| ";\n"
-        )(
           "export type " |+| valueType |+| "<" |+| tpArgsPlain |+| "> = " |+| generateValueType(model) |+| ";"
+        )(
+          "export const " |+| codecName |+| " = " |+| tpArgsIots |+| fnArgs |+| codec |+| ";\n"
         )
       )), model)
     } else
@@ -812,9 +812,9 @@ final class TsGenerator(
         f(
           "export type " |+| codecType |+| " = " |+| generateCodecType(model) |+| ";\n"
         )(
-          "export const " |+| codecName |+| ": " |+| codecType |+| " = " |+| codec |+| ";\n"
-        )(
           "export type " |+| valueType |+| " = " |+| generateValueType(model) |+| ";\n"
+        )(
+          "export const " |+| codecName |+| ": " |+| codecType |+| " = " |+| codec |+| ";\n"
         )
       )), model)
   }

--- a/src/main/scala/scalats/TsGenerator.scala
+++ b/src/main/scala/scalats/TsGenerator.scala
@@ -795,14 +795,14 @@ final class TsGenerator(
 
     if (hasTypeArgs) {
       val updState = State(false, WrapCodec.id)
-      val tpArgsPlain = model.typeArgs.intercalateMap(imports.lift(","))(genNotTop(updState, _))
+      val tpArgsPlain = "<" |+| model.typeArgs.intercalateMap(imports.lift(", "))(genNotTop(updState, _)) |+| ">"
       val tpArgsIots = typeArgsMixed(updState, model.typeArgs)
-      val fnArgs = typeArgsFnParams(updState, model.typeArgs, Some(codecType |+| "<" |+| tpArgsPlain |+| ">"))
+      val fnArgs = typeArgsFnParams(updState, model.typeArgs, Some(codecType |+| tpArgsPlain))
       generate(State(true, WrapCodec(codec => f =>
         f(
           "export type " |+| codecType |+| tpArgsIots |+| " = " |+| generateCodecType(model) |+| ";\n"
         )(
-          "export type " |+| valueType |+| "<" |+| tpArgsPlain |+| "> = " |+| generateValueType(model) |+| ";"
+          "export type " |+| valueType |+| tpArgsPlain |+| " = " |+| generateValueType(model) |+| ";\n"
         )(
           "export const " |+| codecName |+| " = " |+| tpArgsIots |+| fnArgs |+| codec |+| ";\n"
         )

--- a/src/main/scala/scalats/TsGenerator.scala
+++ b/src/main/scala/scalats/TsGenerator.scala
@@ -144,7 +144,7 @@ final class TsGenerator(
     ) |+| ")" |+| retType.fold(Generated.empty)(t => ": " |+| t) |+| " => "
 
   /**
-   * The `io-ts` value corresponding to a Scala `Map`
+   * The `io-ts` type corresponding to a Scala `Map`
    *
    * Produces a TypeScript `Record` when the keys are `string`s and a `ReadonlyMap` otherwise
    */
@@ -276,7 +276,7 @@ final class TsGenerator(
     })
   }
 
-  /** Produces code that refers to a given value, represented by its `typeName` and `typeArgs` */
+  /** Produces code that refers to a given type, represented by its `typeName` and `typeArgs` */
   private def generateTypeRef(typeName: TypeName, typeArgs: List[TsModel], isUnion: Boolean): Generated =
     customType.tpe(typeName.raw).getOrElse(
       imports.custom(typeName, cap(mkCodecName(typeName, isUnion))) |+|

--- a/src/main/scala/scalats/TsGenerator.scala
+++ b/src/main/scala/scalats/TsGenerator.scala
@@ -804,7 +804,14 @@ final class TsGenerator(
         )(
           "export type " |+| valueType |+| tpArgsPlain |+| " = " |+| generateValueType(model) |+| ";\n"
         )(
-          "export const " |+| codecName |+| " = " |+| tpArgsIots |+| fnArgs |+| codec |+| ";\n"
+          "export const " |+| codecName |+| " = " |+| tpArgsIots |+| fnArgs |+| codec |+| " satisfies " |+|
+          imports.iotsTypeType(
+            valueType |+| "<" |+|
+              model.typeArgs.intercalateMap(imports.lift(", "))(t => imports.iotsTypeOf(generateValueType(t))) |+|
+            ">",
+            imports.unknownType
+          ) |+|
+          ";\n"
         )
       )), model)
     } else
@@ -814,7 +821,9 @@ final class TsGenerator(
         )(
           "export type " |+| valueType |+| " = " |+| generateValueType(model) |+| ";\n"
         )(
-          "export const " |+| codecName |+| ": " |+| codecType |+| " = " |+| codec |+| ";\n"
+          "export const " |+| codecName |+| ": " |+| codecType |+| " = " |+| codec |+| " satisfies " |+|
+          imports.iotsTypeType(valueType, imports.unknownType) |+|
+          ";\n"
         )
       )), model)
   }

--- a/src/main/scala/scalats/TsGenerator.scala
+++ b/src/main/scala/scalats/TsGenerator.scala
@@ -32,16 +32,16 @@ extension [F[_], A](fa: F[A])(using F: Foldable[F]) {
  * Generates
  *
  * ```ts
- * export const testC = t.number;
- * export type TestC = typeof testC;
- * export type Test = t.TypeOf<TestC>;
+ * export type TestC = t.NumberC;
+ * export type Test = number;
+ * export const testC: TestC = t.number satisfies t.Type<Test, unknown>;
  * ```
  *
  * ### Using generate with top = true
  *
  * ```scala
  * generate(
- *   State(true, codec => "export const codec = " |+| codec |+| ";")),
+ *   State(true, WrapCodec(codec => _ => "export const codec = " |+| codec |+| ";")),
  *   TsModel.Number(TypeName("Test"))
  * )
  * ```
@@ -55,7 +55,10 @@ extension [F[_], A](fa: F[A])(using F: Foldable[F]) {
  * ### Using generate with top = false
  *
  * ```scala
- * generate(State(false, identity))
+ * generate(
+ *   State(false, g.WrapCodec(codec => _ => codec)),
+ *   TsModel.Number(TypeName("Test"))
+ * )
  * ```
  *
  * Produces

--- a/src/main/scala/scalats/TsGenerator.scala
+++ b/src/main/scala/scalats/TsGenerator.scala
@@ -405,7 +405,13 @@ final class TsGenerator(
     union.possibilities match {
       case Nil => sys.error(s"Can't generate TS code for union `${union.typeName}` with 0 members")
       case h :: Nil => generateType(h)
-      case l @ (_ :: _) => imports.iotsUnionC("[" |+| l.toList.intercalateMap(imports.lift(", "))(generateType) |+| "]")
+      case l @ (_ :: _) =>
+        imports.iotsUnionC("[" |+|
+          l.map {
+            case TsModel.Interface(typeName, _, typeArgs, _) => TsModel.InterfaceRef(typeName, typeArgs)
+            case TsModel.Object(typeName, _, _) => TsModel.ObjectRef(typeName)
+          }.intercalateMap(imports.lift(", "))(generateType) |+|
+        "]")
     }
 
   /** Produces value code for a scala `enum`/`sealed trait`/`sealed class` */

--- a/src/main/scala/scalats/TsImports.scala
+++ b/src/main/scala/scalats/TsImports.scala
@@ -64,7 +64,7 @@ extends Exception(s"Failed to resolve import for type `${importedTypeName.full}`
 class TsImports private (private val m: Map[TsImport.Location, TsImport]) {
   import TsImports.*
 
-  private[TsImports] final lazy val toList: List[(TsImport.Location, TsImport)] = m.toList
+  final lazy val toList: List[(TsImport.Location, TsImport)] = m.toList
 
   override final lazy val toString: String =
     s"TsImports(${toList.flatMap {
@@ -108,7 +108,7 @@ class TsImports private (private val m: Map[TsImport.Location, TsImport]) {
           (accImports, i match {
             case TsImportNames(names) =>
               names.foldLeft(accCode) {
-                case (acc, importedNameRx(newName, oldName)) => acc.replace(oldName, newName)
+                case (acc, importedNameRx(newName, oldName, _)) => acc.replace(oldName, newName)
                 case (acc, _) => acc
               }
             case TsImport_*(_) => accCode
@@ -162,9 +162,37 @@ object TsImports {
   def names(typeName: TypeName, name1: String, otherNames: String*): TsImports =
     new TsImports(Map(TsImport.Unresolved(typeName) -> TsImportNames(otherNames.toSet + name1)))
 
+  /**
+   * Produce a [[scalats.Generated]] that refers to a value imported from a known location
+   *
+   * @param loc The location to import the value from
+   * @param valueName The name of the value to import
+   * @param alias An optional alias for the imported value
+   */
+  def namedImport(loc: String, valueName: String, alias: Option[String]): Generated =
+    Generated(names(loc, alias.fold(valueName)(a => s"$valueName as $a")), alias.getOrElse(valueName))
+
+  /**
+   * Produce a [[scalats.Generated]] that refers to a value imported from a known location
+   *
+   * @param loc The location to import the value from
+   * @param valueName The name of the value to import
+   */
+  def namedImport(loc: String, valueName: String): Generated = namedImport(loc, valueName, None)
+
+  /**
+   * Produce a [[scalats.Generated]] that refers to a value imported from the file in which `typeName` is generated
+   *
+   * @param typeName The name of the type used to resolve the import
+   * @param valueName The name of the value to import
+   * @param alias An optional alias for the imported value
+   */
+  def namedImport(typeName: TypeName, valueName: String, alias: Option[String]): Generated =
+    Generated(names(typeName, alias.fold(valueName)(a => s"$valueName as $a")), alias.getOrElse(valueName))
+
   given monoid: Monoid[TsImports] = Monoid.instance(empty, _ ++ _)
 
-  private val importedNameRx = "^(.*?) as (imported\\d+_\\1)$".r
+  val importedNameRx = "^(.*?) as (imported(\\d+)_\\1)$".r
   private val tsFileRx = "^(.*)\\.tsx?$".r
 
   /** Relativize `filePath` from `fromPath` */
@@ -195,7 +223,12 @@ object TsImports {
   object CallableImport {
     def apply(t: Generated): CallableImport = CallableImport(t.imports, t.code)
     def apply(t: Generated, p: String, s: String): CallableImport = CallableImport(t.imports, t.code, p, s)
+
+    def tpe(t: Generated): CallableImport = CallableImport(t.imports, t.code, "<", ">")
+    def tpe(tsImports: TsImports, name: String): CallableImport = CallableImport(tsImports, name, "<", ">")
   }
+
+  case class ConfiguredImport(tpe: Generated, value: Generated)
 
   /**
    * TypeScript imports config to control where certain values and types are imported from
@@ -217,17 +250,41 @@ object TsImports {
     fptsThese: String = "fp-ts/lib/These",
     fptsPipe: (String, String) = ("pipe", "fp-ts/lib/function"),
     iots: String = "io-ts",
-    iotsDateTime: (String, String) = ("DateFromISOString", "io-ts-types/lib/DateFromISOString"),
-    iotsReadonlyMapFromEntries: (String, String) = ("readonlyMapFromEntries", "io-ts-types/lib/readonlyMapFromEntries"),
-    iotsReadonlyNonEmptyArray: (String, String) = ("readonlyNonEmptyArray", "io-ts-types/lib/readonlyNonEmptyArray"),
-    iotsReadonlySetFromArray: (String, String) = ("readonlySetFromArray", "io-ts-types/lib/readonlySetFromArray"),
-    iotsNumberFromString: (String, String) = ("NumberFromString", "io-ts-types/lib/NumberFromString"),
-    iotsOption: (String, String) = ("optionFromNullable", "io-ts-types/lib/optionFromNullable"),
-    iotsUUID: (String, String) = ("UUID", "io-ts-types/lib/UUID"),
-    iotsBigNumber: Option[(String, String)] = None,
-    iotsEither: Option[(String, String)] = None,
-    iotsLocalDate: Option[(String, String)] = None,
-    iotsThese: Option[(String, String)] = None
+    iotsDateTime: ConfiguredImport = ConfiguredImport(
+      namedImport("io-ts-types/lib/DateFromISOString", "DateFromISOStringC"),
+      namedImport("io-ts-types/lib/DateFromISOString", "DateFromISOString"),
+    ),
+    iotsReadonlyMapFromEntries: ConfiguredImport = ConfiguredImport(
+      namedImport("io-ts-types/lib/readonlyMapFromEntries", "ReadonlyMapFromEntriesC"),
+      namedImport("io-ts-types/lib/readonlyMapFromEntries", "readonlyMapFromEntries"),
+    ),
+    iotsReadonlyNonEmptyArray: ConfiguredImport = ConfiguredImport(
+      namedImport("io-ts-types/lib/readonlyNonEmptyArray", "ReadonlyNonEmptyArrayC"),
+      namedImport("io-ts-types/lib/readonlyNonEmptyArray", "readonlyNonEmptyArray"),
+    ),
+    iotsReadonlySetFromArray: ConfiguredImport = ConfiguredImport(
+      namedImport("io-ts-types/lib/readonlySetFromArray", "ReadonlySetFromArrayC"),
+      namedImport("io-ts-types/lib/readonlySetFromArray", "readonlySetFromArray"),
+    ),
+    iotsNumberFromString: ConfiguredImport = ConfiguredImport(
+      namedImport("io-ts-types/lib/NumberFromString", "NumberFromStringC"),
+      namedImport("io-ts-types/lib/NumberFromString", "NumberFromString"),
+    ),
+    iotsOption: ConfiguredImport = ConfiguredImport(
+      namedImport("io-ts-types/lib/optionFromNullable", "OptionFromNullableC"),
+      namedImport("io-ts-types/lib/optionFromNullable", "optionFromNullable"),
+    ),
+    iotsUUID: ConfiguredImport = ConfiguredImport(
+      Generated(names("io-ts-types/lib/UUID", "UUID"), "typeof UUID"),
+      namedImport("io-ts-types/lib/UUID", "UUID"),
+    ),
+    iotsEither: ConfiguredImport = ConfiguredImport(
+      namedImport("io-ts-types/lib/either", "EitherC"),
+      namedImport("io-ts-types/lib/either", "either"),
+    ),
+    iotsBigNumber: Option[ConfiguredImport] = None,
+    iotsLocalDate: Option[ConfiguredImport] = None,
+    iotsThese: Option[ConfiguredImport] = None
   )
 
   /** A set of TypeScript imports available to use during code generation */
@@ -236,46 +293,12 @@ object TsImports {
 
     val lift = Generated.lift
 
-    /**
-     * Produce a [[scalats.Generated]] that refers to a value imported from a known location
-     *
-     * @param loc The location to import the value from
-     * @param valueName The name of the value to import
-     * @param alias An optional alias for the imported value
-     */
-    final def namedImport(loc: String, valueName: String, alias: Option[String]): Generated =
-      Generated(names(loc, alias.fold(valueName)(a => s"$valueName as $a")), alias.getOrElse(valueName))
-
-    /**
-     * Produce a [[scalats.Generated]] that refers to a value imported from a known location
-     *
-     * @param loc The location to import the value from
-     * @param valueName The name of the value to import
-     */
-    final def namedImport(loc: String, valueName: String): Generated = namedImport(loc, valueName, None)
-
-    /**
-     * Produce a [[scalats.Generated]] that refers to a value imported from the file in which `typeName` is generated
-     *
-     * @param typeName The name of the type used to resolve the import
-     * @param valueName The name of the value to import
-     * @param alias An optional alias for the imported value
-     */
-    final def namedImport(typeName: TypeName, valueName: String, alias: Option[String]): Generated =
-      Generated(names(typeName, alias.fold(valueName)(a => s"$valueName as $a")), alias.getOrElse(valueName))
-
-    /**
-     * Produce a [[scalats.Generated]] that refers to a value imported from the file in which `typeName` is generated
-     *
-     * @param typeName The name of the type used to resolve the import
-     * @param valueName The name of the value to import
-     */
-    final def namedImport(typeName: TypeName, valueName: String): Generated = namedImport(typeName, valueName, None)
+    export TsImports.namedImport
 
     private def namedImport(t: (String, String)): Generated = namedImport(t._2, t._1)
 
-    private def optImport(o: Option[(String, String)], tpeName: String, cfgKey: String): Generated =
-      o.map(namedImport).getOrElse(sys.error(s"$tpeName type requested but $cfgKey import config value missing"))
+    private def optImport(o: Option[Generated], tpeName: String, cfgKey: String): Generated =
+      o.getOrElse(sys.error(s"$tpeName type requested but $cfgKey import config value missing"))
 
     /** A helper to refer to values from a given import location */
     final class FptsUtil(imprt: tsi.type => String) {
@@ -310,69 +333,109 @@ object TsImports {
     final lazy val iotsImport = all(tsi.iots, "t")
     /** Reference to `iots.boolean` */
     final lazy val iotsBoolean = Generated(iotsImport, "t.boolean")
+    /** Reference to the `iots.BooleanC` type */
+    final lazy val iotsBooleanC = Generated(iotsImport, "t.BooleanC")
     /** Helper to call the `iots.brand` function */
     final lazy val iotsBrand = CallableImport(iotsImport, "t.brand")
     /** Helper to refer to the `iots.Branded` type */
-    final lazy val iotsBrandedType = CallableImport(iotsImport, "t.Branded", "<", ">")
+    final lazy val iotsBrandedType = CallableImport.tpe(iotsImport, "t.Branded")
     /** Helper to refer to the `iots.Context` type */
     final lazy val iotsContext = Generated(iotsImport, "t.Context")
     /** Helper to refer to the `iots.Errors` type */
     final lazy val iotsErrors = Generated(iotsImport, "t.Errors")
     /** Helper to call the `iots.literal` function */
     final lazy val iotsLiteral = CallableImport(iotsImport, "t.literal")
+    /** Reference to the `iots.LiteralC` type */
+    final lazy val iotsLiteralC = CallableImport.tpe(iotsImport, "t.LiteralC")
     /** Reference to the `iots.Mixed` type */
     final lazy val iotsMixed = Generated(iotsImport, "t.Mixed")
     /** Reference to `iots.null` */
     final lazy val iotsNull = Generated(iotsImport, "t.null")
     /** Reference to `iots.number` */
     final lazy val iotsNumber = Generated(iotsImport, "t.number")
+    /** Reference to the `iots.NumberC` type */
+    final lazy val iotsNumberC = Generated(iotsImport, "t.NumberC")
     /** Helper to call the `iots.readonlyArray` function */
     final lazy val iotsReadonlyArray = CallableImport(iotsImport, "t.readonlyArray")
+    /** Reference to the `iots.ReadonlyArrayC` type */
+    final lazy val iotsReadonlyArrayC = CallableImport.tpe(iotsImport, "t.ReadonlyArrayC")
+    /** Reference to the `iots.RecordC` type */
+    final lazy val iotsRecordC = CallableImport.tpe(iotsImport, "t.RecordC")
     /** Helper to call the `iots.record` function */
     final lazy val iotsRecord = CallableImport(iotsImport, "t.record")
     /** Helper to call the `iots.strict` function */
     final lazy val iotsStrict = CallableImport(iotsImport, "t.strict")
     /** Reference to `iots.string` */
     final lazy val iotsString = Generated(iotsImport, "t.string")
+    /** Reference to the `iots.StringC` type */
+    final lazy val iotsStringC = Generated(iotsImport, "t.StringC")
+    /** Reference to the `iots.TupleC` type */
+    final lazy val iotsTupleC = CallableImport.tpe(iotsImport, "t.TupleC")
     /** Helper to call the `iots.tuple` function */
     final lazy val iotsTuple = CallableImport(iotsImport, "t.tuple")
     /** Helper to call the `iots.type` function */
     final lazy val iotsTypeFunction = CallableImport(iotsImport, "t.type")
     /** Reference to the `iots.Type` type */
-    final lazy val iotsTypeType = Generated(iotsImport, "t.Type")
+    final lazy val iotsTypeType = CallableImport.tpe(iotsImport, "t.Type")
     /** Reference to the `iots.TypeC` type */
-    final lazy val iotsTypeTypeC = Generated(iotsImport, "t.TypeC")
+    final lazy val iotsTypeTypeC = CallableImport.tpe(iotsImport, "t.TypeC")
     /** Helper to refer to the `iots.TypeOf` type */
-    final lazy val iotsTypeOf = CallableImport(iotsImport, "t.TypeOf", "<", ">")
+    final lazy val iotsTypeOf = CallableImport.tpe(iotsImport, "t.TypeOf")
     /** Reference to `iots.undefined` */
     final lazy val iotsUndefined = Generated(iotsImport, "t.undefined")
     /** Helper to call the `iots.union` function */
     final lazy val iotsUnion = CallableImport(iotsImport, "t.union")
+    /** Reference to the `iots.UnionC` type */
+    final lazy val iotsUnionC = CallableImport.tpe(iotsImport, "t.UnionC")
     /** Reference to `iots.unknown` */
     final lazy val iotsUnknown = Generated(iotsImport, "t.unknown")
+    /** Reference to the `iots.UnknownC` type */
+    final lazy val iotsUnknownC = Generated(iotsImport, "t.UnknownC")
 
+    /** Reference to the configured `iotsDateTime` type */
+    final lazy val iotsDateTimeType = tsi.iotsDateTime.tpe
     /** Reference to the configured `iotsDateTime` value */
-    final lazy val iotsDateTime = namedImport(tsi.iotsDateTime)
+    final lazy val iotsDateTimeValue = tsi.iotsDateTime.value
+    /** Helper to call the configured `iotsReadonlyMapFromEntries` type */
+    final lazy val iotsReadonlyMapFromEntriesType = CallableImport.tpe(tsi.iotsReadonlyMapFromEntries.tpe)
     /** Helper to call the configured `iotsReadonlyMapFromEntries` function */
-    final lazy val iotsReadonlyMapFromEntries = CallableImport(namedImport(tsi.iotsReadonlyMapFromEntries))
+    final lazy val iotsReadonlyMapFromEntriesValue = CallableImport(tsi.iotsReadonlyMapFromEntries.value)
+    /** Helper to call the configured `iotsReadonlyNonEmptyArray` type */
+    final lazy val iotsReadonlyNonEmptyArrayType = CallableImport.tpe(tsi.iotsReadonlyNonEmptyArray.tpe)
     /** Helper to call the configured `iotsReadonlyNonEmptyArray` function */
-    final lazy val iotsReadonlyNonEmptyArray = CallableImport(namedImport(tsi.iotsReadonlyNonEmptyArray))
+    final lazy val iotsReadonlyNonEmptyArrayValue = CallableImport(tsi.iotsReadonlyNonEmptyArray.value)
+    /** Helper to call the configured `iotsReadonlySetFromArray` type */
+    final lazy val iotsReadonlySetFromArrayType = CallableImport.tpe(tsi.iotsReadonlySetFromArray.tpe)
     /** Helper to call the configured `iotsReadonlySetFromArray` function */
-    final lazy val iotsReadonlySetFromArray = CallableImport(namedImport(tsi.iotsReadonlySetFromArray))
+    final lazy val iotsReadonlySetFromArrayValue = CallableImport(tsi.iotsReadonlySetFromArray.value)
+    /** Reference to the configured `iotsNumberFromString` type */
+    final lazy val iotsNumberFromStringType = tsi.iotsNumberFromString.tpe
     /** Reference to the configured `iotsNumberFromString` value */
-    final lazy val iotsNumberFromString = namedImport(tsi.iotsNumberFromString)
+    final lazy val iotsNumberFromStringValue = tsi.iotsNumberFromString.value
     /** Helper to call the configured `iotsOption` function */
-    final lazy val iotsOption = CallableImport(namedImport(tsi.iotsOption))
+    final lazy val iotsOptionType = CallableImport.tpe(tsi.iotsOption.tpe)
+    /** Helper to call the configured `iotsOption` function */
+    final lazy val iotsOptionValue = CallableImport(tsi.iotsOption.value)
+    /** Reference to the configured `iotsBigNumber` type */
+    final lazy val iotsBigNumberType = optImport(tsi.iotsBigNumber.map(_.tpe), "BigNumber", "iotsBigNumber")
     /** Reference to the configured `iotsBigNumber` value */
-    final lazy val iotsBigNumber = optImport(tsi.iotsBigNumber, "BigNumber", "iotsBigNumber")
+    final lazy val iotsBigNumberValue = optImport(tsi.iotsBigNumber.map(_.value), "BigNumber", "iotsBigNumber")
+    /** Helper to call the configured `iotsEither` type */
+    final lazy val iotsEitherType = CallableImport.tpe(tsi.iotsEither.tpe)
     /** Helper to call the configured `iotsEither` function */
-    final lazy val iotsEither = CallableImport(optImport(tsi.iotsEither, "Either", "iotsEither"))
+    final lazy val iotsEitherValue = CallableImport(tsi.iotsEither.value)
     /** Reference to the configured `iotsLocalDate` value */
-    final lazy val iotsLocalDate = optImport(tsi.iotsLocalDate, "LocalDate", "iotsLocalDate")
+    final lazy val iotsLocalDateType = optImport(tsi.iotsLocalDate.map(_.tpe), "LocalDate", "iotsLocalDate")
+    /** Reference to the configured `iotsLocalDate` value */
+    final lazy val iotsLocalDateValue = optImport(tsi.iotsLocalDate.map(_.value), "LocalDate", "iotsLocalDate")
+    /** Helper to call the configured `iotsThese` type */
+    final lazy val iotsTheseType = CallableImport.tpe(optImport(tsi.iotsThese.map(_.tpe), "These", "iotsThese"))
     /** Helper to call the configured `iotsThese` function */
-    final lazy val iotsThese = CallableImport(optImport(tsi.iotsThese, "These", "iotsThese"))
+    final lazy val iotsTheseValue = CallableImport(optImport(tsi.iotsThese.map(_.value), "These", "iotsThese"))
+    /** Reference to the configured `iotsUUID` type */
+    final lazy val iotsUUIDType = tsi.iotsUUID.tpe
     /** Reference to the configured `iotsUUID` value */
-    final lazy val iotsUUID = namedImport(tsi.iotsUUID)
+    final lazy val iotsUUIDValue = tsi.iotsUUID.value
 
     private var incr = Map.empty[String, Int]
 

--- a/src/main/scala/scalats/TsImports.scala
+++ b/src/main/scala/scalats/TsImports.scala
@@ -228,8 +228,6 @@ object TsImports {
     def tpe(tsImports: TsImports, name: String): CallableImport = CallableImport(tsImports, name, "<", ">")
   }
 
-  case class ConfiguredImport[ValueTpe[_]](valueType: ValueTpe[Generated], codecType: Generated, codecValue: Generated)
-
   type Never[A] = None.type
 
   /**
@@ -252,49 +250,49 @@ object TsImports {
     fptsThese: String = "fp-ts/lib/These",
     fptsPipe: (String, String) = ("pipe", "fp-ts/lib/function"),
     iots: String = "io-ts",
-    iotsDateTime: ConfiguredImport[Id] = ConfiguredImport(
-      Generated.lift("Date"),
-      namedImport("io-ts-types/lib/DateFromISOString", "DateFromISOStringC"),
-      namedImport("io-ts-types/lib/DateFromISOString", "DateFromISOString"),
+    iotsDateTime: ReferenceCode[Id] = ReferenceCode(
+      valueType = Generated.lift("Date"),
+      codecType = namedImport("io-ts-types/lib/DateFromISOString", "DateFromISOStringC"),
+      codecValue = namedImport("io-ts-types/lib/DateFromISOString", "DateFromISOString"),
     ),
-    iotsReadonlyMapFromEntries: ConfiguredImport[Never] = ConfiguredImport(
-      None,
-      namedImport("io-ts-types/lib/readonlyMapFromEntries", "ReadonlyMapFromEntriesC"),
-      namedImport("io-ts-types/lib/readonlyMapFromEntries", "readonlyMapFromEntries"),
+    iotsReadonlyMapFromEntries: ReferenceCode[Never] = ReferenceCode(
+      valueType = None,
+      codecType = namedImport("io-ts-types/lib/readonlyMapFromEntries", "ReadonlyMapFromEntriesC"),
+      codecValue = namedImport("io-ts-types/lib/readonlyMapFromEntries", "readonlyMapFromEntries"),
     ),
-    iotsReadonlyNonEmptyArray: ConfiguredImport[Never] = ConfiguredImport(
-      None,
-      namedImport("io-ts-types/lib/readonlyNonEmptyArray", "ReadonlyNonEmptyArrayC"),
-      namedImport("io-ts-types/lib/readonlyNonEmptyArray", "readonlyNonEmptyArray"),
+    iotsReadonlyNonEmptyArray: ReferenceCode[Never] = ReferenceCode(
+      valueType = None,
+      codecType = namedImport("io-ts-types/lib/readonlyNonEmptyArray", "ReadonlyNonEmptyArrayC"),
+      codecValue = namedImport("io-ts-types/lib/readonlyNonEmptyArray", "readonlyNonEmptyArray"),
     ),
-    iotsReadonlySetFromArray: ConfiguredImport[Never] = ConfiguredImport(
-      None,
-      namedImport("io-ts-types/lib/readonlySetFromArray", "ReadonlySetFromArrayC"),
-      namedImport("io-ts-types/lib/readonlySetFromArray", "readonlySetFromArray"),
+    iotsReadonlySetFromArray: ReferenceCode[Never] = ReferenceCode(
+      valueType = None,
+      codecType = namedImport("io-ts-types/lib/readonlySetFromArray", "ReadonlySetFromArrayC"),
+      codecValue = namedImport("io-ts-types/lib/readonlySetFromArray", "readonlySetFromArray"),
     ),
-    iotsNumberFromString: ConfiguredImport[Never] = ConfiguredImport(
-      None,
-      namedImport("io-ts-types/lib/NumberFromString", "NumberFromStringC"),
-      namedImport("io-ts-types/lib/NumberFromString", "NumberFromString"),
+    iotsNumberFromString: ReferenceCode[Never] = ReferenceCode(
+      valueType = None,
+      codecType = namedImport("io-ts-types/lib/NumberFromString", "NumberFromStringC"),
+      codecValue = namedImport("io-ts-types/lib/NumberFromString", "NumberFromString"),
     ),
-    iotsOption: ConfiguredImport[Never] = ConfiguredImport(
-      None,
-      namedImport("io-ts-types/lib/optionFromNullable", "OptionFromNullableC"),
-      namedImport("io-ts-types/lib/optionFromNullable", "optionFromNullable"),
+    iotsOption: ReferenceCode[Never] = ReferenceCode(
+      valueType = None,
+      codecType = namedImport("io-ts-types/lib/optionFromNullable", "OptionFromNullableC"),
+      codecValue = namedImport("io-ts-types/lib/optionFromNullable", "optionFromNullable"),
     ),
-    iotsUUID: ConfiguredImport[Id] = ConfiguredImport(
-      namedImport("io-ts-types/lib/UUID", "UUID"),
-      Generated(names("io-ts-types/lib/UUID", "UUID"), "typeof UUID"),
-      namedImport("io-ts-types/lib/UUID", "UUID"),
+    iotsUUID: ReferenceCode[Id] = ReferenceCode(
+      valueType = namedImport("io-ts-types/lib/UUID", "UUID"),
+      codecType = Generated(names("io-ts-types/lib/UUID", "UUID"), "typeof UUID"),
+      codecValue = namedImport("io-ts-types/lib/UUID", "UUID"),
     ),
-    iotsEither: ConfiguredImport[Never] = ConfiguredImport(
-      None,
-      namedImport("io-ts-types/lib/either", "EitherC"),
-      namedImport("io-ts-types/lib/either", "either"),
+    iotsEither: ReferenceCode[Never] = ReferenceCode(
+      valueType = None,
+      codecType = namedImport("io-ts-types/lib/either", "EitherC"),
+      codecValue = namedImport("io-ts-types/lib/either", "either"),
     ),
-    iotsBigNumber: Option[ConfiguredImport[Id]] = None,
-    iotsLocalDate: Option[ConfiguredImport[Id]] = None,
-    iotsThese: Option[ConfiguredImport[Never]] = None
+    iotsBigNumber: Option[ReferenceCode[Id]] = None,
+    iotsLocalDate: Option[ReferenceCode[Id]] = None,
+    iotsThese: Option[ReferenceCode[Never]] = None
   )
 
   /** A set of TypeScript imports available to use during code generation */

--- a/src/main/scala/scalats/TsImports.scala
+++ b/src/main/scala/scalats/TsImports.scala
@@ -228,7 +228,7 @@ object TsImports {
     def tpe(tsImports: TsImports, name: String): CallableImport = CallableImport(tsImports, name, "<", ">")
   }
 
-  case class ConfiguredImport[ValueTpe[_]](valueType: ValueTpe[Generated], codecType: Generated, value: Generated)
+  case class ConfiguredImport[ValueTpe[_]](valueType: ValueTpe[Generated], codecType: Generated, codecValue: Generated)
 
   type Never[A] = None.type
 
@@ -405,57 +405,57 @@ object TsImports {
     /** Reference to the configured `iotsDateTime` codec type */
     final lazy val iotsDateTimeType = tsi.iotsDateTime.codecType
     /** Reference to the configured `iotsDateTime` value */
-    final lazy val iotsDateTimeValue = tsi.iotsDateTime.value
+    final lazy val iotsDateTimeValue = tsi.iotsDateTime.codecValue
 
     /** Helper to call the configured `iotsReadonlyMapFromEntries` codec type */
     final lazy val iotsReadonlyMapFromEntriesType = CallableImport.tpe(tsi.iotsReadonlyMapFromEntries.codecType)
     /** Helper to call the configured `iotsReadonlyMapFromEntries` function */
-    final lazy val iotsReadonlyMapFromEntriesValue = CallableImport(tsi.iotsReadonlyMapFromEntries.value)
+    final lazy val iotsReadonlyMapFromEntriesValue = CallableImport(tsi.iotsReadonlyMapFromEntries.codecValue)
 
     /** Helper to call the configured `iotsReadonlyNonEmptyArray` codec type */
     final lazy val iotsReadonlyNonEmptyArrayType = CallableImport.tpe(tsi.iotsReadonlyNonEmptyArray.codecType)
     /** Helper to call the configured `iotsReadonlyNonEmptyArray` function */
-    final lazy val iotsReadonlyNonEmptyArrayValue = CallableImport(tsi.iotsReadonlyNonEmptyArray.value)
+    final lazy val iotsReadonlyNonEmptyArrayValue = CallableImport(tsi.iotsReadonlyNonEmptyArray.codecValue)
 
     /** Helper to call the configured `iotsReadonlySetFromArray` codec type */
     final lazy val iotsReadonlySetFromArrayType = CallableImport.tpe(tsi.iotsReadonlySetFromArray.codecType)
     /** Helper to call the configured `iotsReadonlySetFromArray` function */
-    final lazy val iotsReadonlySetFromArrayValue = CallableImport(tsi.iotsReadonlySetFromArray.value)
+    final lazy val iotsReadonlySetFromArrayValue = CallableImport(tsi.iotsReadonlySetFromArray.codecValue)
 
     /** Reference to the configured `iotsNumberFromString` codec type */
     final lazy val iotsNumberFromStringType = tsi.iotsNumberFromString.codecType
     /** Reference to the configured `iotsNumberFromString` value */
-    final lazy val iotsNumberFromStringValue = tsi.iotsNumberFromString.value
+    final lazy val iotsNumberFromStringValue = tsi.iotsNumberFromString.codecValue
 
     /** Helper to call the configured `iotsOption` codec type */
     final lazy val iotsOptionType = CallableImport.tpe(tsi.iotsOption.codecType)
     /** Helper to call the configured `iotsOption` function */
-    final lazy val iotsOptionValue = CallableImport(tsi.iotsOption.value)
+    final lazy val iotsOptionValue = CallableImport(tsi.iotsOption.codecValue)
 
     /** Reference to the configured `iotsBigNumber` codec type */
     final lazy val iotsBigNumberType = optImport(tsi.iotsBigNumber.map(_.codecType), "BigNumber", "iotsBigNumber")
     /** Reference to the configured `iotsBigNumber` value */
-    final lazy val iotsBigNumberValue = optImport(tsi.iotsBigNumber.map(_.value), "BigNumber", "iotsBigNumber")
+    final lazy val iotsBigNumberValue = optImport(tsi.iotsBigNumber.map(_.codecValue), "BigNumber", "iotsBigNumber")
 
     /** Helper to call the configured `iotsEither` codec type */
     final lazy val iotsEitherType = CallableImport.tpe(tsi.iotsEither.codecType)
     /** Helper to call the configured `iotsEither` function */
-    final lazy val iotsEitherValue = CallableImport(tsi.iotsEither.value)
+    final lazy val iotsEitherValue = CallableImport(tsi.iotsEither.codecValue)
 
     /** Reference to the configured `iotsLocalDate` codec type */
     final lazy val iotsLocalDateType = optImport(tsi.iotsLocalDate.map(_.codecType), "LocalDate", "iotsLocalDate")
     /** Reference to the configured `iotsLocalDate` value */
-    final lazy val iotsLocalDateValue = optImport(tsi.iotsLocalDate.map(_.value), "LocalDate", "iotsLocalDate")
+    final lazy val iotsLocalDateValue = optImport(tsi.iotsLocalDate.map(_.codecValue), "LocalDate", "iotsLocalDate")
 
     /** Helper to call the configured `iotsThese` codec type */
     final lazy val iotsTheseType = CallableImport.tpe(optImport(tsi.iotsThese.map(_.codecType), "These", "iotsThese"))
     /** Helper to call the configured `iotsThese` function */
-    final lazy val iotsTheseValue = CallableImport(optImport(tsi.iotsThese.map(_.value), "These", "iotsThese"))
+    final lazy val iotsTheseValue = CallableImport(optImport(tsi.iotsThese.map(_.codecValue), "These", "iotsThese"))
 
     /** Reference to the configured `iotsUUID` codec type */
     final lazy val iotsUUIDType = tsi.iotsUUID.codecType
     /** Reference to the configured `iotsUUID` value */
-    final lazy val iotsUUIDValue = tsi.iotsUUID.value
+    final lazy val iotsUUIDValue = tsi.iotsUUID.codecValue
 
     final lazy val unknownType = Generated.lift("unknown")
     final lazy val stringType = Generated.lift("string")

--- a/src/main/scala/scalats/package.scala
+++ b/src/main/scala/scalats/package.scala
@@ -110,5 +110,5 @@ def referenceCode(model: TsModel)(
   imports: TsImports.Available,
 ): Generated = {
   val generator = new TsGenerator(customType, customOrd, imports)
-  generator.generate(generator.State(false, generator.WrapCodec.id), model).foldMap(_._2)
+  generator.generateCodecValue(generator.State(false, generator.WrapCodec.id), model).foldMap(_._2)
 }

--- a/src/main/scala/scalats/package.scala
+++ b/src/main/scala/scalats/package.scala
@@ -1,5 +1,6 @@
 package scalats
 
+import cats.Id
 import cats.syntax.foldable.*
 import java.io.{File, PrintStream}
 import scala.quoted.*
@@ -108,7 +109,11 @@ def referenceCode(model: TsModel)(
   using customType: TsCustomType,
   customOrd: TsCustomOrd,
   imports: TsImports.Available,
-): Generated = {
+): ReferenceCode[Id] = {
   val generator = new TsGenerator(customType, customOrd, imports)
-  generator.generateCodecValue(generator.State(false, generator.WrapCodec.id), model).foldMap(_._2)
+  ReferenceCode[Id](
+    valueType = generator.generateValueType(model),
+    codecType = generator.generateCodecType(model),
+    codecValue = generator.generateCodecValue(generator.State(false, generator.WrapCodec.id), model).foldMap(_._2),
+  )
 }

--- a/src/test/scala/scalats/tests/InterfaceTest.scala
+++ b/src/test/scala/scalats/tests/InterfaceTest.scala
@@ -23,26 +23,32 @@ export type FooC = t.TypeC<{
   int: t.NumberC,
   str: t.StringC
 }>;
+export type Foo = {
+  int: number,
+  str: string
+};
 export const fooC: FooC = t.type({
   int: t.number,
   str: t.string
-});
-export type Foo = t.TypeOf<FooC>;
+}) satisfies t.Type<Foo, unknown>;
 """.trim
 
   val expectedBarCode = """
-import { FooC as imported0_FooC, fooC as imported0_fooC } from "./foo";
+import { FooC as imported0_FooC, Foo as imported0_Foo, fooC as imported0_fooC } from "./foo";
 import * as t from "io-ts";
 
 export type BarC = t.TypeC<{
   foo: imported0_FooC,
   bool: t.BooleanC
 }>;
+export type Bar = {
+  foo: imported0_Foo,
+  bool: boolean
+};
 export const barC: BarC = t.type({
   foo: imported0_fooC,
   bool: t.boolean
-});
-export type Bar = t.TypeOf<BarC>;
+}) satisfies t.Type<Bar, unknown>;
 """.trim
 
   val fooFile = "foo.ts"

--- a/src/test/scala/scalats/tests/InterfaceTest.scala
+++ b/src/test/scala/scalats/tests/InterfaceTest.scala
@@ -19,23 +19,29 @@ object InterfaceTest {
   val expectedFooCode = """
 import * as t from "io-ts";
 
-export const fooC = t.type({
+export type FooC = t.TypeC<{
+  int: t.NumberC,
+  str: t.StringC
+}>;
+export const fooC: FooC = t.type({
   int: t.number,
   str: t.string
 });
-export type FooC = typeof fooC;
 export type Foo = t.TypeOf<FooC>;
 """.trim
 
   val expectedBarCode = """
-import { fooC as imported0_fooC } from "./foo";
+import { FooC as imported0_FooC, fooC as imported0_fooC } from "./foo";
 import * as t from "io-ts";
 
-export const barC = t.type({
+export type BarC = t.TypeC<{
+  foo: imported0_FooC,
+  bool: t.BooleanC
+}>;
+export const barC: BarC = t.type({
   foo: imported0_fooC,
   bool: t.boolean
 });
-export type BarC = typeof barC;
 export type Bar = t.TypeOf<BarC>;
 """.trim
 

--- a/src/test/scala/scalats/tests/InterfaceWithTypeParamTest.scala
+++ b/src/test/scala/scalats/tests/InterfaceWithTypeParamTest.scala
@@ -14,12 +14,14 @@ object InterfaceWithTypeParamTest {
   val expectedFooCode = """
 import * as t from "io-ts";
 
-export class fooCC<A1 extends t.Mixed>{ codec = (A1: A1) => t.type({
+export type FooC<A1 extends t.Mixed> = t.TypeC<{
+  int: t.NumberC,
+  data: A1
+}>;
+export const fooC = <A1 extends t.Mixed>(A1: A1): FooC<A1> => t.type({
   int: t.number,
   data: A1
-})}
-export const fooC = <A1 extends t.Mixed>(A1: A1) => new fooCC<A1>().codec(A1);
-export type FooC<A1 extends t.Mixed> = ReturnType<fooCC<A1>["codec"]>;
+});
 export type Foo<A1> = t.TypeOf<FooC<t.Type<A1>>>;
 """.trim
 

--- a/src/test/scala/scalats/tests/InterfaceWithTypeParamTest.scala
+++ b/src/test/scala/scalats/tests/InterfaceWithTypeParamTest.scala
@@ -18,11 +18,14 @@ export type FooC<A1 extends t.Mixed> = t.TypeC<{
   int: t.NumberC,
   data: A1
 }>;
+export type Foo<A1> = {
+  int: number,
+  data: A1
+};
 export const fooC = <A1 extends t.Mixed>(A1: A1): FooC<A1> => t.type({
   int: t.number,
   data: A1
-});
-export type Foo<A1> = t.TypeOf<FooC<t.Type<A1>>>;
+}) satisfies t.Type<Foo<t.TypeOf<A1>>, unknown>;
 """.trim
 
   val fooFile = "foo.ts"

--- a/src/test/scala/scalats/tests/ObjectTest.scala
+++ b/src/test/scala/scalats/tests/ObjectTest.scala
@@ -30,12 +30,16 @@ export const foo = {
   str: `test`
 } as const;
 
-export const fooC = t.type({
+export type FooC = t.TypeC<{
+  _tag: t.LiteralC<`Foo`>,
+  int: t.LiteralC<1>,
+  str: t.LiteralC<`test`>
+}>;
+export const fooC: FooC = t.type({
   _tag: t.literal(`Foo`),
   int: t.literal(1),
   str: t.literal(`test`)
 });
-export type FooC = typeof fooC;
 export type Foo = t.TypeOf<FooC>;
 """.trim
 

--- a/src/test/scala/scalats/tests/ObjectTest.scala
+++ b/src/test/scala/scalats/tests/ObjectTest.scala
@@ -35,12 +35,16 @@ export type FooC = t.TypeC<{
   int: t.LiteralC<1>,
   str: t.LiteralC<`test`>
 }>;
+export type Foo = {
+  _tag: `Foo`,
+  int: 1,
+  str: `test`
+};
 export const fooC: FooC = t.type({
   _tag: t.literal(`Foo`),
   int: t.literal(1),
   str: t.literal(`test`)
-});
-export type Foo = t.TypeOf<FooC>;
+}) satisfies t.Type<Foo, unknown>;
 """.trim
 
   val fooFile = "foo.ts"

--- a/src/test/scala/scalats/tests/UnionWithInterfaceTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithInterfaceTest.scala
@@ -30,27 +30,33 @@ export const bar = {
   str: `bar`
 } as const;
 
-export const barTaggedC = t.type({
+export type BarTaggedC = t.TypeC<{
+  _tag: t.LiteralC<`Bar`>
+}>;
+export const barTaggedC: BarTaggedC = t.type({
   _tag: t.literal(`Bar`)
 });
-export type BarTaggedC = typeof barTaggedC;
 export type BarTagged = t.TypeOf<BarTaggedC>;
 export type Bar = BarTagged & typeof bar;
-export const barC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
+export type BarC = t.Type<Bar, BarTagged>;
+export const barC: BarC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   `Bar`,
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
 ));
-export type BarC = typeof barC;
 
 
-export const bazC = t.type({
+export type BazC = t.TypeC<{
+  _tag: t.LiteralC<`Baz`>,
+  int: t.NumberC,
+  str: t.StringC
+}>;
+export const bazC: BazC = t.type({
   _tag: t.literal(`Baz`),
   int: t.number,
   str: t.string
 });
-export type BazC = typeof bazC;
 export type Baz = t.TypeOf<BazC>;
 
 
@@ -58,8 +64,8 @@ export const allFooC = [barC, bazC] as const;
 export const allFooNames = [`Bar`, `Baz`] as const;
 export type FooName = (typeof allFooNames)[number];
 
-export const FooCU = t.union([barC, bazC]);
-export type FooCU = typeof FooCU;
+export type FooCU = t.UnionC<[BarC, BazC]>;
+export const FooCU: FooCU = t.union([barC, bazC]);
 export type FooU = t.TypeOf<FooCU>;
 
 export type FooMap<A> = { [K in FooName]: A };

--- a/src/test/scala/scalats/tests/UnionWithInterfaceTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithInterfaceTest.scala
@@ -44,7 +44,7 @@ export const barC: BarC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
-));
+)) satisfies t.Type<Bar, unknown>;
 
 
 export type BazC = t.TypeC<{
@@ -52,12 +52,16 @@ export type BazC = t.TypeC<{
   int: t.NumberC,
   str: t.StringC
 }>;
+export type Baz = {
+  _tag: `Baz`,
+  int: number,
+  str: string
+};
 export const bazC: BazC = t.type({
   _tag: t.literal(`Baz`),
   int: t.number,
   str: t.string
-});
-export type Baz = t.TypeOf<BazC>;
+}) satisfies t.Type<Baz, unknown>;
 
 
 export const allFooC = [barC, bazC] as const;
@@ -65,8 +69,8 @@ export const allFooNames = [`Bar`, `Baz`] as const;
 export type FooName = (typeof allFooNames)[number];
 
 export type FooCU = t.UnionC<[BarC, BazC]>;
-export const FooCU: FooCU = t.union([barC, bazC]);
-export type FooU = t.TypeOf<FooCU>;
+export type FooU = Bar | Baz;
+export const FooCU: FooCU = t.union([barC, bazC]) satisfies t.Type<FooU, unknown>;
 
 export type FooMap<A> = { [K in FooName]: A };
 """.trim

--- a/src/test/scala/scalats/tests/UnionWithObjectsTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithObjectsTest.scala
@@ -49,7 +49,7 @@ export const barC: BarC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
-));
+)) satisfies t.Type<Bar, unknown>;
 
 
 export const baz = {
@@ -72,7 +72,7 @@ export const bazC: BazC = pipe(bazTaggedC, c => new t.Type<Baz, BazTagged>(
   (u: unknown): u is Baz => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Baz> => pipe(c.decode(u), E.map(x => ({ ...x, ...baz }))),
   (x: Baz): BazTagged => ({ ...x, _tag: `Baz`}),
-));
+)) satisfies t.Type<Baz, unknown>;
 
 
 export const allFooC = [barC, bazC] as const;
@@ -80,8 +80,8 @@ export const allFooNames = [`Bar`, `Baz`] as const;
 export type FooName = (typeof allFooNames)[number];
 
 export type FooCU = t.UnionC<[BarC, BazC]>;
-export const FooCU: FooCU = t.union([barC, bazC]);
-export type FooU = t.TypeOf<FooCU>;
+export type FooU = Bar | Baz;
+export const FooCU: FooCU = t.union([barC, bazC]) satisfies t.Type<FooU, unknown>;
 
 export const fooOrd: Ord.Ord<FooU> = pipe(stringOrd, Ord.contramap(x => x._tag));
 export const allFoo = [bar, baz] as const;

--- a/src/test/scala/scalats/tests/UnionWithObjectsTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithObjectsTest.scala
@@ -35,19 +35,21 @@ export const bar = {
   str: `bar`
 } as const;
 
-export const barTaggedC = t.type({
+export type BarTaggedC = t.TypeC<{
+  _tag: t.LiteralC<`Bar`>
+}>;
+export const barTaggedC: BarTaggedC = t.type({
   _tag: t.literal(`Bar`)
 });
-export type BarTaggedC = typeof barTaggedC;
 export type BarTagged = t.TypeOf<BarTaggedC>;
 export type Bar = BarTagged & typeof bar;
-export const barC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
+export type BarC = t.Type<Bar, BarTagged>;
+export const barC: BarC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   `Bar`,
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
 ));
-export type BarC = typeof barC;
 
 
 export const baz = {
@@ -56,27 +58,29 @@ export const baz = {
   str: `baz`
 } as const;
 
-export const bazTaggedC = t.type({
+export type BazTaggedC = t.TypeC<{
+  _tag: t.LiteralC<`Baz`>
+}>;
+export const bazTaggedC: BazTaggedC = t.type({
   _tag: t.literal(`Baz`)
 });
-export type BazTaggedC = typeof bazTaggedC;
 export type BazTagged = t.TypeOf<BazTaggedC>;
 export type Baz = BazTagged & typeof baz;
-export const bazC = pipe(bazTaggedC, c => new t.Type<Baz, BazTagged>(
+export type BazC = t.Type<Baz, BazTagged>;
+export const bazC: BazC = pipe(bazTaggedC, c => new t.Type<Baz, BazTagged>(
   `Baz`,
   (u: unknown): u is Baz => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Baz> => pipe(c.decode(u), E.map(x => ({ ...x, ...baz }))),
   (x: Baz): BazTagged => ({ ...x, _tag: `Baz`}),
 ));
-export type BazC = typeof bazC;
 
 
 export const allFooC = [barC, bazC] as const;
 export const allFooNames = [`Bar`, `Baz`] as const;
 export type FooName = (typeof allFooNames)[number];
 
-export const FooCU = t.union([barC, bazC]);
-export type FooCU = typeof FooCU;
+export type FooCU = t.UnionC<[BarC, BazC]>;
+export const FooCU: FooCU = t.union([barC, bazC]);
 export type FooU = t.TypeOf<FooCU>;
 
 export const fooOrd: Ord.Ord<FooU> = pipe(stringOrd, Ord.contramap(x => x._tag));

--- a/src/test/scala/scalats/tests/UnionWithTypeParamTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithTypeParamTest.scala
@@ -44,7 +44,7 @@ export const barC: BarC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
-));
+)) satisfies t.Type<Bar, unknown>;
 
 
 export type BazC<A1 extends t.Mixed> = t.TypeC<{
@@ -52,20 +52,25 @@ export type BazC<A1 extends t.Mixed> = t.TypeC<{
   int: t.NumberC,
   data: A1
 }>;
+export type Baz<A1> = {
+  _tag: `Baz`,
+  int: number,
+  data: A1
+};
 export const bazC = <A1 extends t.Mixed>(A1: A1): BazC<A1> => t.type({
   _tag: t.literal(`Baz`),
   int: t.number,
   data: A1
-});
-export type Baz<A1> = t.TypeOf<BazC<t.Type<A1>>>;
+}) satisfies t.Type<Baz<t.TypeOf<A1>>, unknown>;
+
 
 export const allFooC = <A1 extends t.Mixed>(A1: A1) => [barC, bazC(A1)] as const;
 export const allFooNames = [`Bar`, `Baz`] as const;
 export type FooName = (typeof allFooNames)[number];
 
 export type FooCU<A1 extends t.Mixed> = t.UnionC<[BarC, BazC<A1>]>;
-export const FooCU = <A1 extends t.Mixed>(A1: A1): FooCU<A1> => t.union([barC, bazC(A1)]);
-export type FooU<A1> = t.TypeOf<FooCU<t.Type<A1>>>;
+export type FooU<A1> = Bar | Baz<A1>;
+export const FooCU = <A1 extends t.Mixed>(A1: A1): FooCU<A1> => t.union([barC, bazC(A1)]) satisfies t.Type<FooU<t.TypeOf<A1>>, unknown>;
 """.trim
 
   val fooFile = "foo.ts"

--- a/src/test/scala/scalats/tests/UnionWithTypeParamTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithTypeParamTest.scala
@@ -30,37 +30,41 @@ export const bar = {
   int: 1
 } as const;
 
-export const barTaggedC = t.type({
+export type BarTaggedC = t.TypeC<{
+  _tag: t.LiteralC<`Bar`>
+}>;
+export const barTaggedC: BarTaggedC = t.type({
   _tag: t.literal(`Bar`)
 });
-export type BarTaggedC = typeof barTaggedC;
 export type BarTagged = t.TypeOf<BarTaggedC>;
 export type Bar = BarTagged & typeof bar;
-export const barC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
+export type BarC = t.Type<Bar, BarTagged>;
+export const barC: BarC = pipe(barTaggedC, c => new t.Type<Bar, BarTagged>(
   `Bar`,
   (u: unknown): u is Bar => E.isRight(c.decode(u)),
   (u: unknown): E.Either<t.Errors, Bar> => pipe(c.decode(u), E.map(x => ({ ...x, ...bar }))),
   (x: Bar): BarTagged => ({ ...x, _tag: `Bar`}),
 ));
-export type BarC = typeof barC;
 
 
-export class bazCC<A1 extends t.Mixed>{ codec = (A1: A1) => t.type({
+export type BazC<A1 extends t.Mixed> = t.TypeC<{
+  _tag: t.LiteralC<`Baz`>,
+  int: t.NumberC,
+  data: A1
+}>;
+export const bazC = <A1 extends t.Mixed>(A1: A1): BazC<A1> => t.type({
   _tag: t.literal(`Baz`),
   int: t.number,
   data: A1
-})}
-export const bazC = <A1 extends t.Mixed>(A1: A1) => new bazCC<A1>().codec(A1);
-export type BazC<A1 extends t.Mixed> = ReturnType<bazCC<A1>["codec"]>;
+});
 export type Baz<A1> = t.TypeOf<BazC<t.Type<A1>>>;
 
 export const allFooC = <A1 extends t.Mixed>(A1: A1) => [barC, bazC(A1)] as const;
 export const allFooNames = [`Bar`, `Baz`] as const;
 export type FooName = (typeof allFooNames)[number];
 
-export class FooCUC<A1 extends t.Mixed>{ codec = (A1: A1) => t.union([barC, bazC(A1)])}
-export const FooCU = <A1 extends t.Mixed>(A1: A1) => new FooCUC<A1>().codec(A1);
-export type FooCU<A1 extends t.Mixed> = ReturnType<FooCUC<A1>["codec"]>;
+export type FooCU<A1 extends t.Mixed> = t.UnionC<[BarC, BazC<A1>]>;
+export const FooCU = <A1 extends t.Mixed>(A1: A1): FooCU<A1> => t.union([barC, bazC(A1)]);
 export type FooU<A1> = t.TypeOf<FooCU<t.Type<A1>>>;
 """.trim
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,5 +5,6 @@
     "io-ts": "2.2.20",
     "ts-node": "10.9.1",
     "typescript": "5.1.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
For a given `case class`:

```scala
case class Foo(int: Int, str: String)
```

### Old generated code

```ts
import * as t from "io-ts";

export const fooC = t.type({
  int: t.number,
  str: t.string
});
export type FooC = typeof fooC;
export type Foo = t.TypeOf<FooC>;
```

### New generated code

Comments are included for explanation

```ts
import * as t from "io-ts";

// The codec type is generated explicitly and does not refer to the codec value
export type FooC = t.TypeC<{
  int: t.NumberC,
  str: t.StringC
}>;
// The value type is generated explicitly and does not refer to the codec type or value
export type Foo = {
  int: number,
  str: string
};
// The codec value is annotated with the codec type
export const fooC: FooC = t.type({
  int: t.number,
  str: t.string
// The codec value is proven to satisfy `t.Type<ValueType, unknown>`
// This isn't strictly necessary but is nice to verify that the generation of types/values aligns
}) satisfies t.Type<Foo, unknown>;
```