### PR TITLE
Support Scala 3 native union types

### DIFF
--- a/src/main/scala/scalats/TsModel.scala
+++ b/src/main/scala/scalats/TsModel.scala
@@ -94,5 +94,6 @@ object TsModel {
   }
   case class Union(typeName: TypeName, typeArgs: List[TsModel], possibilities: List[Object | Interface]) extends TsModel
   case class UnionRef(typeName: TypeName, typeArgs: List[TsModel], allObjects: scala.Boolean) extends TsModel
+  case class UnionTypeRef(typeName: TypeName, typeArgs: List[TsModel], possibilities: List[TsModel]) extends TsModel
   case class Unknown(typeName: TypeName, typeArgs: List[TsModel]) extends TsModel
 }

--- a/src/test/scala/scalats/tests/Arbitrary.scala
+++ b/src/test/scala/scalats/tests/Arbitrary.scala
@@ -6,25 +6,30 @@ import scala.compiletime.erasedValue
 import scala.deriving.Mirror
 
 object arbitrary {
-  inline given derivedArbitrary[A](using A: Mirror.Of[A]): Arbitrary[A] = {
-    val insts = summonInsts[A.MirroredElemTypes]
+  extension (a: Arbitrary.type) {
+    inline def derived[A](using A: Mirror.Of[A]): Arbitrary[A] = {
+      val insts = summonInsts[A.MirroredElemTypes]
 
-    inline A match {
-      case m: Mirror.ProductOf[A] => Arbitrary(insts.foldRight(Gen.const[Tuple](EmptyTuple))((arb, acc) =>
-        arb.arbitrary.flatMap(h => acc.map(h *: _)),
-      ).map(t => m.fromTuple(t.asInstanceOf[m.MirroredElemTypes])))
+      inline A match {
+        case m: Mirror.ProductOf[A] => Arbitrary(insts.foldRight(Gen.const[Tuple](EmptyTuple))((arb, acc) =>
+          arb.arbitrary.flatMap(h => acc.map(h *: _)),
+        ).map(t => m.fromTuple(t.asInstanceOf[m.MirroredElemTypes])))
 
-    case _: Mirror.SumOf[A] =>
-      Arbitrary((insts match {
-        case a :: b :: rest => Gen.oneOf(a.arbitrary, b.arbitrary, rest.map(_.arbitrary)*)
-        case a :: Nil => a.arbitrary
-        case Nil => Gen.const(null)
-      }).map(_.asInstanceOf[A]))
+      case _: Mirror.SumOf[A] =>
+        Arbitrary((insts match {
+          case a :: b :: rest => Gen.oneOf(a.arbitrary, b.arbitrary, rest.map(_.arbitrary)*)
+          case a :: Nil => a.arbitrary
+          case Nil => Gen.const(null)
+        }).map(_.asInstanceOf[A]))
+      }
     }
   }
 
   private inline def summonInst[A]: Arbitrary[A] =
-    compiletime.summonFrom { case a: Arbitrary[A] => a }
+    compiletime.summonFrom {
+      case a: Arbitrary[A] => a
+      case m: Mirror.Of[A] => Arbitrary.derived[A]
+    }
 
   private inline def summonInsts[T <: Tuple]: List[Arbitrary[Any]] =
     inline erasedValue[T] match {

--- a/src/test/scala/scalats/tests/InterfaceTest.scala
+++ b/src/test/scala/scalats/tests/InterfaceTest.scala
@@ -1,20 +1,13 @@
 package scalats
 package tests
 
-import io.circe.{Decoder, Encoder}
-import scalats.tests.arbitrary.given
+import io.circe.derivation.{ConfiguredDecoder, ConfiguredEncoder}
+import org.scalacheck.Arbitrary
+import scalats.tests.arbitrary.*
 
 object InterfaceTest {
-  case class Foo(int: Int, str: String)
-  object Foo {
-    given decoder: Decoder[Foo] = Decoder.derivedConfigured
-    given encoder: Encoder[Foo] = Encoder.AsObject.derivedConfigured
-  }
-  case class Bar(foo: Foo, bool: Boolean)
-  object Bar {
-    given decoder: Decoder[Bar] = Decoder.derivedConfigured
-    given encoder: Encoder[Bar] = Encoder.AsObject.derivedConfigured
-  }
+  case class Foo(int: Int, str: String) derives Arbitrary, ConfiguredDecoder, ConfiguredEncoder
+  case class Bar(foo: Foo, bool: Boolean) derives Arbitrary, ConfiguredDecoder, ConfiguredEncoder
 
   val expectedFooCode = """
 import * as t from "io-ts";

--- a/src/test/scala/scalats/tests/InterfaceWithTypeParamTest.scala
+++ b/src/test/scala/scalats/tests/InterfaceWithTypeParamTest.scala
@@ -2,10 +2,11 @@ package scalats
 package tests
 
 import io.circe.{Decoder, Encoder}
-import scalats.tests.arbitrary.given
+import org.scalacheck.Arbitrary
+import scalats.tests.arbitrary.*
 
 object InterfaceWithTypeParamTest {
-  case class Foo[A](int: Int, data: A)
+  case class Foo[A](int: Int, data: A) derives Arbitrary
   object Foo {
     given decoder[A: Decoder]: Decoder[Foo[A]] = Decoder.derivedConfigured
     given encoder[A: Encoder]: Encoder[Foo[A]] = Encoder.AsObject.derivedConfigured

--- a/src/test/scala/scalats/tests/ObjectTest.scala
+++ b/src/test/scala/scalats/tests/ObjectTest.scala
@@ -3,7 +3,7 @@ package tests
 
 import io.circe.{Decoder, Encoder, JsonObject}
 import io.circe.syntax.*
-import scalats.tests.arbitrary.given
+import org.scalacheck.{Arbitrary, Gen}
 
 object ObjectTest {
   case object Foo {
@@ -19,6 +19,8 @@ object ObjectTest {
 
     given encoder: Encoder[Foo.type] =
       Encoder.AsObject.instance(foo => JsonObject("_tag" := "Foo", "int" := foo.int, "str" := foo.str))
+
+    given arb: Arbitrary[Foo.type] = Arbitrary(Gen.const(Foo))
   }
 
   val expectedFooCode = """

--- a/src/test/scala/scalats/tests/UnionNativeTest.scala
+++ b/src/test/scala/scalats/tests/UnionNativeTest.scala
@@ -1,0 +1,55 @@
+package scalats
+package tests
+
+import cats.syntax.functor.*
+import io.circe.{Decoder, Encoder}
+import io.circe.derivation.{ConfiguredDecoder, ConfiguredEncoder}
+import io.circe.syntax.*
+import org.scalacheck.{Arbitrary, Gen}
+import scalats.tests.arbitrary.*
+
+object UnionNativeTest {
+  case class Foo(run: Int | String) derives Arbitrary, ConfiguredDecoder, ConfiguredEncoder
+  object Foo {
+    private given intOrStringDecoder: Decoder[Int | String] =
+      Decoder[Int].widen[Int | String].or(Decoder[String].widen[Int | String])
+
+    private given intOrStringEncoder: Encoder[Int | String] =
+      Encoder.instance {
+        case i: Int => i.asJson
+        case s: String => s.asJson
+      }
+
+    private given intOrStringArb: Arbitrary[Int | String] =
+      Arbitrary(Gen.oneOf(
+        Arbitrary.arbitrary[Int].map(identity[Int | String]),
+        Arbitrary.arbitrary[String].map(identity[Int | String]),
+      ))
+  }
+
+  val expectedFooCode = """
+import * as t from "io-ts";
+
+export type FooC = t.TypeC<{
+  run: t.UnionC<[t.NumberC, t.StringC]>
+}>;
+export type Foo = {
+  run: number | string
+};
+export const fooC: FooC = t.type({
+  run: t.union([t.number, t.string])
+}) satisfies t.Type<Foo, unknown>;
+""".trim
+
+  val fooFile = "foo.ts"
+
+  val types = Map(fooFile -> (List(parse[Foo]), expectedFooCode))
+}
+
+class UnionNativeTest extends CodecTest[UnionNativeTest.Foo](
+  outputDir / "unionNative",
+  UnionNativeTest.types,
+  "fooC",
+  "fooC",
+  UnionNativeTest.fooFile,
+)

--- a/src/test/scala/scalats/tests/UnionWithInterfaceTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithInterfaceTest.scala
@@ -1,17 +1,14 @@
 package scalats
 package tests
 
-import io.circe.{Decoder, Encoder}
-import scalats.tests.arbitrary.given
+import io.circe.derivation.{ConfiguredDecoder, ConfiguredEncoder}
+import org.scalacheck.Arbitrary
+import scalats.tests.arbitrary.*
 
 object UnionWithInterfaceTest {
-  sealed trait Foo {
+  sealed trait Foo derives Arbitrary, ConfiguredDecoder, ConfiguredEncoder {
     val int: Int
     val str: String
-  }
-  object Foo {
-    given decoder: Decoder[Foo] = Decoder.derivedConfigured
-    given encoder: Encoder[Foo] = Encoder.AsObject.derivedConfigured
   }
   case object Bar extends Foo {
     val int = 1

--- a/src/test/scala/scalats/tests/UnionWithObjectsTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithObjectsTest.scala
@@ -1,17 +1,14 @@
 package scalats
 package tests
 
-import io.circe.{Decoder, Encoder}
-import scalats.tests.arbitrary.given
+import io.circe.derivation.{ConfiguredDecoder, ConfiguredEncoder}
+import org.scalacheck.Arbitrary
+import scalats.tests.arbitrary.*
 
 object UnionWithObjectsTest {
-  sealed trait Foo {
+  sealed trait Foo derives Arbitrary, ConfiguredDecoder, ConfiguredEncoder {
     val int: Int
     val str: String
-  }
-  object Foo {
-    given decoder: Decoder[Foo] = Decoder.derivedConfigured
-    given encoder: Encoder[Foo] = Encoder.AsObject.derivedConfigured
   }
   case object Bar extends Foo {
     val int = 1

--- a/src/test/scala/scalats/tests/UnionWithTypeParamTest.scala
+++ b/src/test/scala/scalats/tests/UnionWithTypeParamTest.scala
@@ -2,10 +2,11 @@ package scalats
 package tests
 
 import io.circe.{Decoder, Encoder}
-import scalats.tests.arbitrary.given
+import org.scalacheck.Arbitrary
+import scalats.tests.arbitrary.*
 
 object UnionWithTypeParamTest {
-  sealed trait Foo[A] {
+  sealed trait Foo[A] derives Arbitrary {
     val int: Int
     val data: A
   }


### PR DESCRIPTION
Now supports native union types, only as type references, i.e.

```scala
// ok
case class Foo(run: Int | String)
scalats.parse[Foo]

// not ok
scalats.parse[Int | String] /*
-- Error: ----------------------------------------------------------------------
1 |scalats.parse[Int | String]
  |^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |Union types are only supported as references */
```